### PR TITLE
Gui refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ $(TARGET): $(OBJS)
 # Reguły kompilacji
 main.o: main.c gui.h
 	@$(CC) $(CFLAGS) -c main.c -o main.o
-gui.o: gui.c gui.h gui_utils.h data_loader.h resampler.h utils.h index_calculator.h visualization.h processing_pipeline.h
+gui.o: gui.c gui.h gui_utils.h data_loader.h resampler.h utils.h index_calculator.h visualization.h processing_pipeline.h data_types.h
 	@$(CC) $(CFLAGS) -c gui.c -o gui.o
 gui_utils.o: gui_utils.c gui_utils.h utils.h
 	@$(CC) $(CFLAGS) -c gui_utils.c -o gui_utils.o
@@ -43,7 +43,7 @@ index_calculator.o: index_calculator.c index_calculator.h
 	@$(CC) $(CFLAGS) -c index_calculator.c -o index_calculator.o
 visualization.o: visualization.c visualization.h index_calculator.h
 	@$(CC) $(CFLAGS) -c visualization.c -o visualization.o
-processing_pipeline.o: processing_pipeline.c processing_pipeline.h data_loader.h resampler.h index_calculator.h utils.h
+processing_pipeline.o: processing_pipeline.c processing_pipeline.h data_loader.h resampler.h index_calculator.h utils.h data_types.h
 	@$(CC) $(CFLAGS) -c processing_pipeline.c -o processing_pipeline.o
 # Reguła czyszczenia
 clean:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ CFLAGS = $(GTK_CFLAGS) $(GDAL_CFLAGS) -Wall -g -std=c11
 LIBS = $(GTK_LIBS) $(GDAL_LIBS) -lm
 
 # Pliki źródłowe
-SRCS = main.c gui.c data_loader.c resampler.c utils.c index_calculator.c visualization.c
+SRCS = main.c gui.c gui_utils.c data_loader.c resampler.c utils.c index_calculator.c visualization.c
 
 # Pliki obiektowe (automatycznie generowane z .c na .o)
 OBJS = $(SRCS:.c=.o)
@@ -36,13 +36,15 @@ all: $(TARGET)
 # Reguła linkowania: tworzy plik wykonywalny z plików obiektowych
 $(TARGET): $(OBJS)
 	@$(CC) $(OBJS) -o $(TARGET) $(LIBS)
-
 # Reguły kompilacji
 main.o: main.c gui.h
 	@$(CC) $(CFLAGS) -c main.c -o main.o
 
-gui.o: gui.c gui.h data_loader.h resampler.h utils.h index_calculator.h visualization.h
+gui.o: gui.c gui.h gui_utils.h data_loader.h resampler.h utils.h index_calculator.h visualization.h
 	@$(CC) $(CFLAGS) -c gui.c -o gui.o
+
+gui_utils.o: gui_utils.c gui_utils.h utils.h
+	@$(CC) $(CFLAGS) -c gui_utils.c -o gui_utils.o
 
 data_loader.o: data_loader.c data_loader.h
 	@$(CC) $(CFLAGS) -c data_loader.c -o data_loader.o

--- a/Makefile
+++ b/Makefile
@@ -1,68 +1,51 @@
 # Kompilator C
 CC = gcc
-
 # Nazwa pliku wykonywalnego
 TARGET = a.out
-
 # Opcje kompilatora i linkera dla GTK+ 3.0 (uzyskane z pkg-config)
 GTK_CFLAGS = $(shell pkg-config --cflags gtk+-3.0)
 GTK_LIBS = $(shell pkg-config --libs gtk+-3.0)
-
 # Opcje kompilatora i linkera dla GDAL (uzyskane z gdal-config)
 GDAL_CFLAGS = $(shell gdal-config --cflags)
 GDAL_LIBS = $(shell gdal-config --libs)
-
 # Usunięto OMP_FLAGS
 # Flagi OpenMP (opcjonalnie, jeśli chcesz użyć #pragma omp)
 # OMP_FLAGS = -fopenmp
-
 # Wszystkie flagi kompilatora
 # Usunięto OMP_FLAGS z CFLAGS
 CFLAGS = $(GTK_CFLAGS) $(GDAL_CFLAGS) -Wall -g -std=c11
-
 # Wszystkie biblioteki do linkowania
 # Usunięto OMP_FLAGS z LIBS
 LIBS = $(GTK_LIBS) $(GDAL_LIBS) -lm
-
 # Pliki źródłowe
-SRCS = main.c gui.c gui_utils.c data_loader.c resampler.c utils.c index_calculator.c visualization.c
-
+SRCS = main.c gui.c gui_utils.c data_loader.c resampler.c utils.c index_calculator.c visualization.c processing_pipeline.c
 # Pliki obiektowe (automatycznie generowane z .c na .o)
 OBJS = $(SRCS:.c=.o)
-
 # Domyślna reguła: buduje program
 all: $(TARGET)
-
 # Reguła linkowania: tworzy plik wykonywalny z plików obiektowych
 $(TARGET): $(OBJS)
 	@$(CC) $(OBJS) -o $(TARGET) $(LIBS)
 # Reguły kompilacji
 main.o: main.c gui.h
 	@$(CC) $(CFLAGS) -c main.c -o main.o
-
-gui.o: gui.c gui.h gui_utils.h data_loader.h resampler.h utils.h index_calculator.h visualization.h
+gui.o: gui.c gui.h gui_utils.h data_loader.h resampler.h utils.h index_calculator.h visualization.h processing_pipeline.h
 	@$(CC) $(CFLAGS) -c gui.c -o gui.o
-
 gui_utils.o: gui_utils.c gui_utils.h utils.h
 	@$(CC) $(CFLAGS) -c gui_utils.c -o gui_utils.o
-
 data_loader.o: data_loader.c data_loader.h
 	@$(CC) $(CFLAGS) -c data_loader.c -o data_loader.o
-
 resampler.o: resampler.c resampler.h
 	@$(CC) $(CFLAGS) -c resampler.c -o resampler.o
-
 utils.o: utils.c utils.h
 	@$(CC) $(CFLAGS) -c utils.c -o utils.o
-
 index_calculator.o: index_calculator.c index_calculator.h
 	@$(CC) $(CFLAGS) -c index_calculator.c -o index_calculator.o
-
 visualization.o: visualization.c visualization.h index_calculator.h
 	@$(CC) $(CFLAGS) -c visualization.c -o visualization.o
-
+processing_pipeline.o: processing_pipeline.c processing_pipeline.h data_loader.h resampler.h index_calculator.h utils.h
+	@$(CC) $(CFLAGS) -c processing_pipeline.c -o processing_pipeline.o
 # Reguła czyszczenia
 clean:
 	@rm -f $(TARGET) $(OBJS)
-
 .PHONY: all clean

--- a/data_loader.c
+++ b/data_loader.c
@@ -24,12 +24,6 @@ int load_all_bands_data(BandData bands[4])
 {
     for (int i = 0; i < 4; i++)
     {
-        if (!*(bands[i].path) || strlen(*(bands[i].path)) == 0)
-        {
-            fprintf(stderr, "[%s] Błąd: Brak ścieżki dla pasma %s.\n", get_timestamp(), bands[i].band_name);
-            return -1;
-        }
-
         *(bands[i].raw_data) = LoadBandData(*(bands[i].path), bands[i].width, bands[i].height);
         if (!*(bands[i].raw_data))
         {

--- a/data_loader.c
+++ b/data_loader.c
@@ -1,8 +1,15 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <sys/time.h>
 #include <gdal.h>
 #include "data_loader.h"
 
+// ====== UTILITY ======
+const char* detect_band_from_filename(const char* filename);
+char* get_timestamp();
+double get_time_diff(struct timeval start, struct timeval end);
 // ====== WALIDACJA ======
 int validate_filename(const char* filename);
 int validate_gdal_dataset(GDALDatasetH dataset, const char* filename);
@@ -16,11 +23,15 @@ void cleanup_gdal_resources(GDALDatasetH dataset, float* buffer);
 CPLErr perform_raster_read(GDALRasterBandH band, float* buffer, int width, int height);
 void set_output_dimensions(int* output_width, int* output_height, int width, int height);
 
-float* LoadBandData(const char* pszFilename, int* pnXSize, int* pnYSize)
-{
+float* LoadBandData(const char* pszFilename, int* pnXSize, int* pnYSize) {
+    const char* band_name = detect_band_from_filename(pszFilename);
+    struct timeval start_time, end_time;
+    gettimeofday(&start_time, NULL);
+
+    printf("[%s] [%s] Rozpoczynam wczytywanie pliku\n", get_timestamp(), band_name);
+
     // Walidacja wejścia
-    if (!validate_filename(pszFilename))
-    {
+    if (!validate_filename(pszFilename)) {
         return NULL;
     }
 
@@ -33,8 +44,7 @@ float* LoadBandData(const char* pszFilename, int* pnXSize, int* pnYSize)
 
     // Otwieranie datasetu
     hDataset = GDALOpen(pszFilename, GA_ReadOnly);
-    if (!validate_gdal_dataset(hDataset, pszFilename))
-    {
+    if (!validate_gdal_dataset(hDataset, pszFilename)) {
         return NULL;
     }
 
@@ -43,8 +53,7 @@ float* LoadBandData(const char* pszFilename, int* pnXSize, int* pnYSize)
     nYSize = GDALGetRasterYSize(hDataset);
 
     // Walidacja wymiarów
-    if (!validate_raster_dimensions(nXSize, nYSize, pszFilename))
-    {
+    if (!validate_raster_dimensions(nXSize, nYSize, pszFilename)) {
         cleanup_gdal_resources(hDataset, NULL);
         return NULL;
     }
@@ -54,24 +63,22 @@ float* LoadBandData(const char* pszFilename, int* pnXSize, int* pnYSize)
 
     // Pobieranie pasma
     hBand = GDALGetRasterBand(hDataset, 1);
-    if (!validate_raster_band(hBand, pszFilename))
-    {
+    if (!validate_raster_band(hBand, pszFilename)) {
         cleanup_gdal_resources(hDataset, NULL);
         return NULL;
     }
 
     // Alokacja bufora
     pafScanline = allocate_band_buffer(nXSize, nYSize, pszFilename);
-    if (pafScanline == NULL)
-    {
+    if (pafScanline == NULL) {
         cleanup_gdal_resources(hDataset, NULL);
         return NULL;
     }
 
     // Wczytywanie danych
+    printf("[%s] [%s] Wczytywanie danych...\n", get_timestamp(), band_name);
     eErr = perform_raster_read(hBand, pafScanline, nXSize, nYSize);
-    if (eErr != CE_None)
-    {
+    if (eErr != CE_None) {
         fprintf(stderr, "Błąd podczas wczytywania danych rastrowych z %s: %s\n",
                 pszFilename, CPLGetLastErrorMsg());
         cleanup_gdal_resources(hDataset, pafScanline);
@@ -81,7 +88,44 @@ float* LoadBandData(const char* pszFilename, int* pnXSize, int* pnYSize)
     // Cleanup (zachowujemy buffer, zamykamy dataset)
     GDALClose(hDataset);
 
+    // Oblicz czas wykonania
+    gettimeofday(&end_time, NULL);
+    double elapsed_time = get_time_diff(start_time, end_time);
+
+    printf("[%s] [%s] Zakończono (czas: %.2fs)\n",
+           get_timestamp(), band_name, elapsed_time);
+
     return pafScanline;
+}
+
+const char* detect_band_from_filename(const char* filename) {
+    if (filename == NULL) return "UNKNOWN";
+
+    if (strstr(filename, "B04") || strstr(filename, "_B04_")) return "B04";
+    if (strstr(filename, "B08") || strstr(filename, "_B08_")) return "B08";
+    if (strstr(filename, "B11") || strstr(filename, "_B11_")) return "B11";
+    if (strstr(filename, "SCL") || strstr(filename, "_SCL_")) return "SCL";
+
+    return "UNKNOWN";
+}
+
+char* get_timestamp() {
+    static char timestamp[64];
+    struct timeval tv;
+    struct tm* tm_info;
+
+    gettimeofday(&tv, NULL);
+    tm_info = localtime(&tv.tv_sec);
+
+    snprintf(timestamp, sizeof(timestamp), "%02d:%02d:%02d.%03ld",
+             tm_info->tm_hour, tm_info->tm_min, tm_info->tm_sec,
+             tv.tv_usec / 1000);
+
+    return timestamp;
+}
+
+double get_time_diff(struct timeval start, struct timeval end) {
+    return (end.tv_sec - start.tv_sec) + (end.tv_usec - start.tv_usec) / 1000000.0;
 }
 
 int validate_filename(const char* filename)

--- a/data_loader.c
+++ b/data_loader.c
@@ -1,71 +1,180 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h> // Dla CPLGetLastErrorMsg w niektórych konfiguracjach GDAL
 #include <gdal.h>
-
 #include "data_loader.h"
 
-// Definicja funkcji LoadBandData (przeniesiona z Twojego "kodzika")
-float* LoadBandData(const char* pszFilename, int* pnXSize, int* pnYSize) {
-    GDALDatasetH hDataset;
-    GDALRasterBandH hBand;
-    float* pafScanline = NULL; // Zainicjuj na NULL
-    int nXSize = 0, nYSize = 0; // Zainicjuj
+// ====== WALIDACJA ======
+int validate_filename(const char* filename);
+int validate_gdal_dataset(GDALDatasetH dataset, const char* filename);
+int validate_raster_dimensions(int width, int height, const char* filename);
+int validate_raster_band(GDALRasterBandH band, const char* filename);
+int validate_buffer_allocation(float* buffer, size_t num_pixels, const char* filename);
+// ====== PAMIĘĆ ======
+float* allocate_band_buffer(int width, int height, const char* filename);
+void cleanup_gdal_resources(GDALDatasetH dataset, float* buffer);
+// ====== FUNKCJONALNOŚĆ ======
+CPLErr perform_raster_read(GDALRasterBandH band, float* buffer, int width, int height);
+void set_output_dimensions(int* output_width, int* output_height, int width, int height);
+
+float* LoadBandData(const char* pszFilename, int* pnXSize, int* pnYSize)
+{
+    // Walidacja wejścia
+    if (!validate_filename(pszFilename))
+    {
+        return NULL;
+    }
+
+    // Inicjalizacja zmiennych
+    GDALDatasetH hDataset = NULL;
+    GDALRasterBandH hBand = NULL;
+    float* pafScanline = NULL;
+    int nXSize = 0, nYSize = 0;
     CPLErr eErr;
 
-    // GDALAllRegister() jest teraz wywoływane w gui.c w run_gui(), więc nie tutaj.
-
+    // Otwieranie datasetu
     hDataset = GDALOpen(pszFilename, GA_ReadOnly);
-    if (hDataset == NULL) {
-        fprintf(stderr, "Nie można otworzyć pliku %s: %s\n", pszFilename, CPLGetLastErrorMsg());
+    if (!validate_gdal_dataset(hDataset, pszFilename))
+    {
         return NULL;
     }
 
+    // Pobieranie wymiarów
     nXSize = GDALGetRasterXSize(hDataset);
     nYSize = GDALGetRasterYSize(hDataset);
-    
-    // Zapisz wymiary tylko jeśli wskaźniki nie są NULL
-    if (pnXSize != NULL) {
-        *pnXSize = nXSize;
-    }
-    if (pnYSize != NULL) {
-        *pnYSize = nYSize;
-    }
 
-    // Sprawdź, czy wymiary są poprawne przed alokacją pamięci
-    if (nXSize <= 0 || nYSize <= 0) {
-        fprintf(stderr, "Nieprawidłowe wymiary rastra w pliku %s (%dx%d).\n", pszFilename, nXSize, nYSize);
-        GDALClose(hDataset);
+    // Walidacja wymiarów
+    if (!validate_raster_dimensions(nXSize, nYSize, pszFilename))
+    {
+        cleanup_gdal_resources(hDataset, NULL);
         return NULL;
     }
 
+    // Ustawienie wymiarów wyjściowych
+    set_output_dimensions(pnXSize, pnYSize, nXSize, nYSize);
+
+    // Pobieranie pasma
     hBand = GDALGetRasterBand(hDataset, 1);
-    if (hBand == NULL) {
-        fprintf(stderr, "Nie można pobrać pasma z pliku %s: %s\n", pszFilename, CPLGetLastErrorMsg());
-        GDALClose(hDataset);
+    if (!validate_raster_band(hBand, pszFilename))
+    {
+        cleanup_gdal_resources(hDataset, NULL);
         return NULL;
     }
 
-    // Użyj size_t dla iloczynu, aby uniknąć przepełnienia przy dużych obrazach
-    size_t num_pixels = (size_t)nXSize * nYSize;
-    pafScanline = (float*)malloc(sizeof(float) * num_pixels);
-    if (pafScanline == NULL) {
-        fprintf(stderr, "Błąd alokacji pamięci dla %zu pikseli danych pasma z pliku %s.\n", num_pixels, pszFilename);
-        GDALClose(hDataset);
+    // Alokacja bufora
+    pafScanline = allocate_band_buffer(nXSize, nYSize, pszFilename);
+    if (pafScanline == NULL)
+    {
+        cleanup_gdal_resources(hDataset, NULL);
         return NULL;
     }
 
-    eErr = GDALRasterIO(hBand, GF_Read, 0, 0, nXSize, nYSize,
-                        pafScanline, nXSize, nYSize, GDT_Float32,
-                        0, 0);
-
-    if (eErr != CE_None) {
-        fprintf(stderr, "Błąd podczas wczytywania danych rastrowych z %s: %s\n", pszFilename, CPLGetLastErrorMsg());
-        free(pafScanline); // Zwolnij pamięć w przypadku błędu IO
-        GDALClose(hDataset);
+    // Wczytywanie danych
+    eErr = perform_raster_read(hBand, pafScanline, nXSize, nYSize);
+    if (eErr != CE_None)
+    {
+        fprintf(stderr, "Błąd podczas wczytywania danych rastrowych z %s: %s\n",
+                pszFilename, CPLGetLastErrorMsg());
+        cleanup_gdal_resources(hDataset, pafScanline);
         return NULL;
     }
 
+    // Cleanup (zachowujemy buffer, zamykamy dataset)
     GDALClose(hDataset);
+
     return pafScanline;
+}
+
+int validate_filename(const char* filename)
+{
+    if (filename == NULL)
+    {
+        fprintf(stderr, "Error: Filename is NULL\n");
+        return 0;
+    }
+    return 1;
+}
+
+int validate_gdal_dataset(GDALDatasetH dataset, const char* filename)
+{
+    if (dataset == NULL)
+    {
+        fprintf(stderr, "Nie można otworzyć pliku %s: %s\n", filename, CPLGetLastErrorMsg());
+        return 0;
+    }
+    return 1;
+}
+
+int validate_raster_dimensions(int width, int height, const char* filename)
+{
+    if (width <= 0 || height <= 0)
+    {
+        fprintf(stderr, "Nieprawidłowe wymiary rastra w pliku %s (%dx%d).\n", filename, width, height);
+        return 0;
+    }
+    return 1;
+}
+
+int validate_raster_band(GDALRasterBandH band, const char* filename)
+{
+    if (band == NULL)
+    {
+        fprintf(stderr, "Nie można pobrać pasma z pliku %s: %s\n", filename, CPLGetLastErrorMsg());
+        return 0;
+    }
+    return 1;
+}
+
+int validate_buffer_allocation(float* buffer, size_t num_pixels, const char* filename)
+{
+    if (buffer == NULL)
+    {
+        fprintf(stderr, "Błąd alokacji pamięci dla %zu pikseli danych pasma z pliku %s.\n", num_pixels, filename);
+        return 0;
+    }
+    return 1;
+}
+
+float* allocate_band_buffer(int width, int height, const char* filename)
+{
+    size_t num_pixels = (size_t)width * height;
+
+    float* buffer = malloc(sizeof(float) * num_pixels);
+
+    if (!validate_buffer_allocation(buffer, num_pixels, filename))
+    {
+        return NULL;
+    }
+
+    return buffer;
+}
+
+void cleanup_gdal_resources(GDALDatasetH dataset, float* buffer)
+{
+    if (buffer != NULL)
+    {
+        free(buffer);
+    }
+    if (dataset != NULL)
+    {
+        GDALClose(dataset);
+    }
+}
+
+CPLErr perform_raster_read(GDALRasterBandH band, float* buffer, int width, int height)
+{
+    return GDALRasterIO(band, GF_Read, 0, 0, width, height,
+                        buffer, width, height, GDT_Float32,
+                        0, 0);
+}
+
+void set_output_dimensions(int* output_width, int* output_height, int width, int height)
+{
+    if (output_width != NULL)
+    {
+        *output_width = width;
+    }
+    if (output_height != NULL)
+    {
+        *output_height = height;
+    }
 }

--- a/data_loader.c
+++ b/data_loader.c
@@ -5,11 +5,8 @@
 #include <sys/time.h>
 #include <gdal.h>
 #include "data_loader.h"
+#include "utils.h"
 
-// ====== UTILITY ======
-const char* detect_band_from_filename(const char* filename);
-char* get_timestamp();
-double get_time_diff(struct timeval start, struct timeval end);
 // ====== WALIDACJA ======
 int validate_filename(const char* filename);
 int validate_gdal_dataset(GDALDatasetH dataset, const char* filename);
@@ -96,36 +93,6 @@ float* LoadBandData(const char* pszFilename, int* pnXSize, int* pnYSize) {
            get_timestamp(), band_name, elapsed_time);
 
     return pafScanline;
-}
-
-const char* detect_band_from_filename(const char* filename) {
-    if (filename == NULL) return "UNKNOWN";
-
-    if (strstr(filename, "B04") || strstr(filename, "_B04_")) return "B04";
-    if (strstr(filename, "B08") || strstr(filename, "_B08_")) return "B08";
-    if (strstr(filename, "B11") || strstr(filename, "_B11_")) return "B11";
-    if (strstr(filename, "SCL") || strstr(filename, "_SCL_")) return "SCL";
-
-    return "UNKNOWN";
-}
-
-char* get_timestamp() {
-    static char timestamp[64];
-    struct timeval tv;
-    struct tm* tm_info;
-
-    gettimeofday(&tv, NULL);
-    tm_info = localtime(&tv.tv_sec);
-
-    snprintf(timestamp, sizeof(timestamp), "%02d:%02d:%02d.%03ld",
-             tm_info->tm_hour, tm_info->tm_min, tm_info->tm_sec,
-             tv.tv_usec / 1000);
-
-    return timestamp;
-}
-
-double get_time_diff(struct timeval start, struct timeval end) {
-    return (end.tv_sec - start.tv_sec) + (end.tv_usec - start.tv_usec) / 1000000.0;
 }
 
 int validate_filename(const char* filename)

--- a/data_loader.h
+++ b/data_loader.h
@@ -1,6 +1,43 @@
 #ifndef DATA_LOADER_H
 #define DATA_LOADER_H
+#include "data_types.h"
 
+/**
+ * @brief Wczytuje dane pasma satelitarnego z pliku GDAL-kompatybilnego
+ *
+ * Funkcja otwiera plik rasterowy przy użyciu biblioteki GDAL, waliduje jego poprawność,
+ * alokuje pamięć i wczytuje dane pierwszego pasma jako tablicę wartości float.
+ *
+ * @param pszFilename Ścieżka do pliku rasterowego (np. plik .jp2 z danymi Sentinel-2)
+ * @param pnXSize Wskaźnik do zmiennej, w której zostanie zapisana szerokość rastra w pikselach
+ * @param pnYSize Wskaźnik do zmiennej, w której zostanie zapisana wysokość rastra w pikselach
+ *
+ * @return Wskaźnik do zaalokowanej tablicy float zawierającej dane pikseli pasma,
+ *         lub NULL w przypadku błędu (nieprawidłowy plik, błąd alokacji pamięci itp.)
+ *
+ * @note Zwrócona pamięć musi zostać zwolniona przez wywołującego przy użyciu free()
+ * @note Funkcja automatycznie wykrywa typ pasma na podstawie nazwy pliku i loguje postęp
+ */
 float* LoadBandData(const char* pszFilename, int* pnXSize, int* pnYSize);
+/**
+ * @brief Wczytuje dane dla wszystkich czterech pasm satelitarnych Sentinel-2
+ *
+ * Funkcja iteruje przez tablicę struktur BandData i wczytuje dane dla każdego pasma
+ * przy użyciu funkcji LoadBandData(). W przypadku błędu dla któregokolwiek pasma,
+ * automatycznie zwalnia już wczytane dane i zwraca błąd.
+ *
+ * @param bands Tablica 4 struktur BandData zawierających informacje o pasmach do wczytania.
+ *              Każda struktura musi zawierać:
+ *              - Wskaźnik do ścieżki pliku (path)
+ *              - Wskaźniki do zmiennych wymiarów (width, height)
+ *              - Wskaźniki do buforów danych (raw_data, processed_data)
+ *              - Nazwę pasma (band_name) do logowania
+ *
+ * @return 0 w przypadku sukcesu (wszystkie pasma wczytane pomyślnie),
+ *         - -1 w przypadku błędu (brak ścieżki, błąd wczytywania lub alokacji pamięci)
+ *
+ * @warning Zakłada, że tablica bands ma dokładnie 4 elementy
+ */
+int load_all_bands_data(BandData bands[4]);
 
 #endif

--- a/data_types.h
+++ b/data_types.h
@@ -1,0 +1,23 @@
+#ifndef DATA_TYPES_H
+#define DATA_TYPES_H
+
+typedef struct
+{
+    char** path;
+    float** raw_data;
+    float** processed_data;
+    int* width;
+    int* height;
+    const char* band_name;
+    int band_index;
+} BandData;
+
+enum BandType
+{
+    B04,
+    B08,
+    B11,
+    SCL
+};
+
+#endif // DATA_TYPES_H

--- a/data_types.h
+++ b/data_types.h
@@ -9,7 +9,6 @@ typedef struct
     int* width;
     int* height;
     const char* band_name;
-    int band_index;
 } BandData;
 
 enum BandType

--- a/gui.c
+++ b/gui.c
@@ -76,9 +76,6 @@ static void free_index_map_data(gpointer data);
 static void free_band_data(BandData bands[4]);
 static void map_window_data_destroy(gpointer data);
 
-// ====== POMOCNICZE ======
-static void show_error_dialog(GtkWindow* parent_window, const char* message);
-
 // ====== IMPLEMENTACJE - GUI GŁÓWNE ======
 
 static void activate_config_window(GtkApplication* app)
@@ -599,21 +596,4 @@ static void map_window_data_destroy(gpointer data)
 
     g_free(window_data);
     g_print("[%s] map_window_data_destroy: Cleanup zakończony.\n", get_timestamp());
-}
-
-// ====== IMPLEMENTACJE - POMOCNICZE ======
-
-static void show_error_dialog(GtkWindow* parent_window, const char* message)
-{
-    if (GTK_IS_WINDOW(parent_window) && gtk_widget_get_visible(GTK_WIDGET(parent_window)))
-    {
-        GtkWidget* error_dialog = gtk_message_dialog_new(parent_window,
-                                                         GTK_DIALOG_DESTROY_WITH_PARENT,
-                                                         GTK_MESSAGE_ERROR,
-                                                         GTK_BUTTONS_CLOSE,
-                                                         "%s", message);
-        gtk_window_set_title(GTK_WINDOW(error_dialog), "Błąd przetwarzania");
-        gtk_dialog_run(GTK_DIALOG(error_dialog));
-        gtk_widget_destroy(error_dialog);
-    }
 }

--- a/gui.c
+++ b/gui.c
@@ -33,6 +33,22 @@ typedef struct
     IndexMapData* map_data;
 } MapWindowData;
 
+typedef struct
+{
+    const char* suffix;
+    const char* prefix;
+    const char* default_text;
+} BandConfig;
+
+// Dane pasma wyświetlane w GUI
+const BandConfig band_configs[] = {
+    {"pasma B04", "B04: ", "Wczytaj pasmo B04"},
+    {"pasma B08", "B08: ", "Wczytaj pasmo B08"},
+    {"pasma B11", "B11: ", "Wczytaj pasmo B11"},
+    {"pasma SCL", "SCL: ", "Wczytaj pasmo SCL"},
+    {NULL, "Plik: ", "Wybierz plik"} // default
+};
+
 // Zmienne globalne
 static char* path_b04 = NULL;
 static char* path_b08 = NULL;
@@ -62,6 +78,13 @@ static void on_load_scl_clicked(GtkWidget* widget, gpointer data);
 static void on_rozpocznij_clicked(GtkWidget* widget, gpointer user_data);
 static void on_config_radio_resolution_toggled(GtkToggleButton* togglebutton);
 static void on_map_type_radio_toggled(GtkToggleButton* togglebutton, gpointer user_data);
+
+// ====== POMOCNICZE ======
+const BandConfig* get_band_config(const gchar* dialog_title_suffix);
+void update_file_selection(char** target_path_variable, GtkButton* button_to_update,
+                           GtkFileChooser* file_chooser, const BandConfig* config);
+void handle_file_selection(GtkWindow* parent_window, const gchar* dialog_title_suffix,
+                           char** target_path_variable, GtkButton* button_to_update);
 
 // ====== WALIDACJA ======
 static int validate_band_paths(BandData bands[], int band_count, GtkWindow* parent_window);
@@ -420,6 +443,57 @@ static void on_map_type_radio_toggled(GtkToggleButton* togglebutton, gpointer us
         }
     }
 }
+
+// ====== IMPLEMENTACJE - POMOCNICZE ======
+
+const BandConfig* get_band_config(const gchar* dialog_title_suffix) {
+    for (int i = 0; band_configs[i].suffix != NULL; i++) {
+        if (g_strcmp0(dialog_title_suffix, band_configs[i].suffix) == 0) {
+            return &band_configs[i];
+        }
+    }
+    return &band_configs[4]; // default
+}
+
+void update_file_selection(char** target_path_variable, GtkButton* button_to_update,
+                          GtkFileChooser* file_chooser, const BandConfig* config) {
+    char* filename_path = gtk_file_chooser_get_filename(file_chooser);
+    if (!filename_path) {
+        return; // Brak wybranego pliku
+    }
+
+    // Zwolnienie starej ścieżki
+    if (*target_path_variable) {
+        g_free(*target_path_variable);
+    }
+    *target_path_variable = g_strdup(filename_path);
+
+    // Aktualizacja etykiety przycisku
+    update_button_label(button_to_update, filename_path, config->prefix);
+
+    g_free(filename_path);
+}
+
+void handle_file_selection(GtkWindow* parent_window, const gchar* dialog_title_suffix,
+                          char** target_path_variable, GtkButton* button_to_update) {
+    const BandConfig* config = get_band_config(dialog_title_suffix);
+
+    char dialog_title[150];
+    snprintf(dialog_title, sizeof(dialog_title), "Wybierz plik dla %s", dialog_title_suffix);
+
+    GtkWidget* dialog = create_file_dialog(parent_window, dialog_title);
+    gint res = gtk_dialog_run(GTK_DIALOG(dialog));
+
+    if (res == GTK_RESPONSE_ACCEPT) {
+        update_file_selection(target_path_variable, button_to_update,
+                             GTK_FILE_CHOOSER(dialog), config);
+    } else if (!(*target_path_variable)) {
+        gtk_button_set_label(button_to_update, config->default_text);
+    }
+
+    gtk_widget_destroy(dialog);
+}
+
 
 // ====== IMPLEMENTACJE - WALIDACJA ======
 

--- a/gui.c
+++ b/gui.c
@@ -34,9 +34,9 @@ typedef struct
 } MapWindowData;
 
 // Deklaracje wprzód
-static void activate_config_window(GtkApplication* app, gpointer user_data);
+static void activate_config_window(GtkApplication* app);
 static gboolean on_draw_map_area(GtkWidget* widget, cairo_t* cr, gpointer user_data);
-static void on_config_window_destroy(GtkWidget* widget, gpointer data);
+static void on_config_window_destroy(GtkWidget* widget);
 static GtkWidget* create_map_window(GtkApplication* app, IndexMapData* map_data);
 
 // Zmienne globalne
@@ -363,13 +363,13 @@ static GtkWidget* create_map_window(GtkApplication* app, IndexMapData* map_data)
 {
     if (!map_data)
     {
-        g_printerr("create_map_window_v3: map_data jest NULL.\n");
+        g_printerr("[%s] Błąd tworzenia mapy --- Brak wskaźnika do mapy.\n", get_timestamp());
         return NULL;
     }
 
     if (!map_data->ndvi_data && !map_data->ndmi_data)
     {
-        g_printerr("create_map_window_v3: Brak danych NDVI/NDMI.\n");
+        g_printerr("[%s] Błąd tworzenia mapy --- Brak danych NDMI / NDVI.\n", get_timestamp());
         free_index_map_data(map_data);
         return NULL;
     }
@@ -442,37 +442,30 @@ static GtkWidget* create_map_window(GtkApplication* app, IndexMapData* map_data)
 
 
 // Handler dla zniszczenia okna konfiguracji
-static void on_config_window_destroy(GtkWidget* widget, gpointer data)
+static void on_config_window_destroy(GtkWidget* widget)
 {
-    g_print("on_config_window_destroy: Okno konfiguracji %p zniszczone. Ustawiam the_config_window na NULL.\n",
-            (void*)widget);
     if (the_config_window == widget)
     {
         the_config_window = NULL;
     }
 }
 
-static void activate_config_window(GtkApplication* app, gpointer user_data)
+static void activate_config_window(GtkApplication* app)
 {
     if (the_config_window)
     {
         if (gtk_widget_get_visible(the_config_window))
         {
-            g_print("activate_config_window: Okno konfiguracji już istnieje i jest widoczne, prezentuję %p.\n",
-                    (void*)the_config_window);
             gtk_window_present(GTK_WINDOW(the_config_window));
         }
         else
         {
-            g_print("activate_config_window: Okno konfiguracji już istnieje, ale nie jest widoczne, pokazuję %p.\n",
-                    (void*)the_config_window);
             gtk_widget_show_all(the_config_window);
             gtk_window_present(GTK_WINDOW(the_config_window));
         }
         return;
     }
 
-    g_print("activate_config_window: Tworzenie nowego okna konfiguracji.\n");
     GtkWidget* config_window_local;
     GtkWidget* main_vbox;
     GtkWidget* radio_hbox_config;

--- a/gui.c
+++ b/gui.c
@@ -335,10 +335,10 @@ static void on_rozpocznij_clicked(GtkWidget* widget, gpointer user_data)
     float* processed_data[4] = {NULL};
 
     BandData bands[4] = {
-        {&path_b04, &btn_load_b04_widget, &raw_data[0], &processed_data[0], &widths[0], &heights[0], "B04", 0},
-        {&path_b08, &btn_load_b08_widget, &raw_data[1], &processed_data[1], &widths[1], &heights[1], "B08", 1},
-        {&path_b11, &btn_load_b11_widget, &raw_data[2], &processed_data[2], &widths[2], &heights[2], "B11", 2},
-        {&path_scl, &btn_load_scl_widget, &raw_data[3], &processed_data[3], &widths[3], &heights[3], "SCL", 3}
+        {&path_b04, &raw_data[0], &processed_data[0], &widths[0], &heights[0], "B04", 0},
+        {&path_b08, &raw_data[1], &processed_data[1], &widths[1], &heights[1], "B08", 1},
+        {&path_b11, &raw_data[2], &processed_data[2], &widths[2], &heights[2], "B11", 2},
+        {&path_scl, &raw_data[3], &processed_data[3], &widths[3], &heights[3], "SCL", 3}
     };
 
     // Walidacja ścieżek plików

--- a/gui.c
+++ b/gui.c
@@ -17,7 +17,8 @@
 #define DEFAULT_WINDOW_WIDTH 900
 #define DEFAULT_WINDOW_HEIGHT 750
 
-typedef struct {
+typedef struct
+{
     float* ndvi_data;
     float* ndmi_data;
     int width;
@@ -26,147 +27,209 @@ typedef struct {
 } IndexMapData;
 
 // ZMODYFIKOWANA struktura dla handlera "delete-event"
-typedef struct {
-    GtkApplication *app;
-    IndexMapData *map_data_to_free; // Dane do zwolnienia przez handler
+typedef struct
+{
+    GtkApplication* app;
+    IndexMapData* map_data_to_free; // Dane do zwolnienia przez handler
     // map_window_widget usunięte, użyjemy argumentu 'widget' z callbacku
 } MapWindowCloseAndCleanupData;
 
 // Deklaracje wprzód
-static void create_and_show_map_window(GtkApplication *app, gpointer user_data);
-static void activate_config_window(GtkApplication *app, gpointer user_data);
-static gboolean on_draw_map_area(GtkWidget *widget, cairo_t *cr, gpointer user_data);
-static gboolean on_map_window_delete_event_manual_cleanup(GtkWidget *widget, GdkEvent *event, gpointer user_data);
-static void on_config_window_destroy(GtkWidget *widget, gpointer data); // Nowa
+static void create_and_show_map_window(GtkApplication* app, gpointer user_data);
+static void activate_config_window(GtkApplication* app, gpointer user_data);
+static gboolean on_draw_map_area(GtkWidget* widget, cairo_t* cr, gpointer user_data);
+static gboolean on_map_window_delete_event_manual_cleanup(GtkWidget* widget, GdkEvent* event, gpointer user_data);
+static void on_config_window_destroy(GtkWidget* widget, gpointer data); // Nowa
 static gboolean destroy_widget_idle(gpointer data); // Nowa
+static const BandConfig* get_band_config(const gchar* dialog_title_suffix);
+static GtkWidget* create_file_dialog(GtkWindow* parent, const char* title);
+static void set_button_label_ellipsis(GtkButton* button);
+static void update_button_label(GtkButton* button, const char* filepath, const char* prefix);
+static void update_file_selection(char** target_path_variable, GtkButton* button_to_update,
+                                 GtkFileChooser* file_chooser, const BandConfig* config);
+static GtkWidget* create_button_with_ellipsis(const char* label);
 
-static char *path_b04 = NULL;
-static char *path_b08 = NULL;
-static char *path_b11 = NULL;
-static char *path_scl = NULL;
+static char* path_b04 = NULL;
+static char* path_b08 = NULL;
+static char* path_b11 = NULL;
+static char* path_scl = NULL;
 static gboolean res_10m_selected = TRUE;
 
-static GtkWidget *btn_load_b04_widget = NULL;
-static GtkWidget *btn_load_b08_widget = NULL;
-static GtkWidget *btn_load_b11_widget = NULL;
-static GtkWidget *btn_load_scl_widget = NULL;
+static GtkWidget* btn_load_b04_widget = NULL;
+static GtkWidget* btn_load_b08_widget = NULL;
+static GtkWidget* btn_load_b11_widget = NULL;
+static GtkWidget* btn_load_scl_widget = NULL;
 
 // Statyczny wskaźnik do okna konfiguracji
-static GtkWidget *the_config_window = NULL;
+static GtkWidget* the_config_window = NULL;
+
+static GtkWidget* create_button_with_ellipsis(const char* label) {
+    GtkWidget* button = gtk_button_new_with_label(label);
+    set_button_label_ellipsis(GTK_BUTTON(button));
+    return button;
+}
 
 
-static void free_index_map_data(gpointer data) {
+static void free_index_map_data(gpointer data)
+{
     g_print("== free_index_map_data (WYWOŁANIE MANUALNE): Rozpoczęto zwalnianie danych mapy ==\n");
-    if (data == NULL) {
+    if (data == NULL)
+    {
         g_print("free_index_map_data: Wskaźnik 'data' jest NULL, kończenie.\n");
         return;
     }
-    IndexMapData *map_data = (IndexMapData*)data;
+    IndexMapData* map_data = (IndexMapData*)data;
     g_print("free_index_map_data: Wskaźnik map_data: %p\n", (void*)map_data);
 
-    if (map_data->ndvi_data) {
+    if (map_data->ndvi_data)
+    {
         g_print("free_index_map_data: Zwalnianie ndvi_data (wskaźnik: %p)...\n", (void*)map_data->ndvi_data);
         free(map_data->ndvi_data);
         map_data->ndvi_data = NULL;
         g_print("free_index_map_data: Zwolniono ndvi_data.\n");
-    } else {
+    }
+    else
+    {
         g_print("free_index_map_data: ndvi_data był NULL.\n");
     }
 
-    if (map_data->ndmi_data) {
+    if (map_data->ndmi_data)
+    {
         g_print("free_index_map_data: Zwalnianie ndmi_data (wskaźnik: %p)...\n", (void*)map_data->ndmi_data);
         free(map_data->ndmi_data);
         map_data->ndmi_data = NULL;
         g_print("free_index_map_data: Zwolniono ndmi_data.\n");
-    } else {
+    }
+    else
+    {
         g_print("free_index_map_data: ndmi_data był NULL.\n");
     }
 
-    g_print("free_index_map_data: Zwalnianie struktury map_data (wskaźnik: %p) za pomocą g_free()...\n", (void*)map_data);
+    g_print("free_index_map_data: Zwalnianie struktury map_data (wskaźnik: %p) za pomocą g_free()...\n",
+            (void*)map_data);
     g_free(map_data);
     g_print("== free_index_map_data: Zakończono zwalnianie danych mapy dla wskaźnika %p ==\n", data);
 }
 
-static void handle_file_selection(GtkWindow *parent_window, const gchar *dialog_title_suffix, char **target_path_variable, GtkButton *button_to_update) {
-    GtkWidget *dialog;
-    GtkFileChooserAction action = GTK_FILE_CHOOSER_ACTION_OPEN;
-    gint res;
-    char dialog_full_title[100];
-    char button_label_prefix[50];
-    char default_button_text[100];
+static const BandConfig* get_band_config(const gchar* dialog_title_suffix) {
+    for (int i = 0; band_configs[i].suffix != NULL; i++) {
+        if (g_strcmp0(dialog_title_suffix, band_configs[i].suffix) == 0) {
+            return &band_configs[i];
+        }
+    }
+    return &band_configs[4]; // default
+}
 
-    if (g_strcmp0(dialog_title_suffix, "pasma B04") == 0) {
-        snprintf(button_label_prefix, sizeof(button_label_prefix), "B04: ");
-        snprintf(default_button_text, sizeof(default_button_text), "Wczytaj pasmo B04");
-    } else if (g_strcmp0(dialog_title_suffix, "pasma B08") == 0) {
-        snprintf(button_label_prefix, sizeof(button_label_prefix), "B08: ");
-        snprintf(default_button_text, sizeof(default_button_text), "Wczytaj pasmo B08");
-    } else if (g_strcmp0(dialog_title_suffix, "pasma B11") == 0) {
-        snprintf(button_label_prefix, sizeof(button_label_prefix), "B11: ");
-        snprintf(default_button_text, sizeof(default_button_text), "Wczytaj pasmo B11");
-    } else if (g_strcmp0(dialog_title_suffix, "pasma SCL") == 0) {
-        snprintf(button_label_prefix, sizeof(button_label_prefix), "SCL: ");
-        snprintf(default_button_text, sizeof(default_button_text), "Wczytaj pasmo SCL");
-    } else {
-        snprintf(button_label_prefix, sizeof(button_label_prefix), "Plik: ");
-        snprintf(default_button_text, sizeof(default_button_text), "Wybierz plik");
+static GtkWidget* create_file_dialog(GtkWindow* parent, const char* title) {
+    GtkWidget* dialog = gtk_file_chooser_dialog_new(
+        title, parent, GTK_FILE_CHOOSER_ACTION_OPEN,
+        "_Anuluj", GTK_RESPONSE_CANCEL,
+        "_Otwórz", GTK_RESPONSE_ACCEPT, NULL);
+
+    // Filtr JP2
+    GtkFileFilter* filter = gtk_file_filter_new();
+    gtk_file_filter_set_name(filter, "Obrazy JP2 (*.jp2)");
+    gtk_file_filter_add_pattern(filter, "*.jp2");
+    gtk_file_filter_add_pattern(filter, "*.JP2");
+    gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(dialog), filter);
+
+    return dialog;
+}
+
+static void set_button_label_ellipsis(GtkButton* button) {
+    GList* children = gtk_container_get_children(GTK_CONTAINER(button));
+    if (children != NULL) {
+        GtkWidget* label_widget = GTK_WIDGET(children->data);
+        if (GTK_IS_LABEL(label_widget)) {
+            gtk_label_set_ellipsize(GTK_LABEL(label_widget), PANGO_ELLIPSIZE_END);
+        }
+        g_list_free(children);
+    }
+}
+
+static void update_button_label(GtkButton* button, const char* filepath, const char* prefix) {
+    const char* short_name = get_short_filename(filepath);
+
+    char new_label[256];
+    snprintf(new_label, sizeof(new_label), "%s%s", prefix, short_name);
+    gtk_button_set_label(button, new_label);
+
+    // Ustawienie ellipsis dla długich nazw
+    set_button_label_ellipsis(button);
+}
+
+static void update_file_selection(char** target_path_variable, GtkButton* button_to_update,
+                                 GtkFileChooser* file_chooser, const BandConfig* config) {
+    char* filename_path = gtk_file_chooser_get_filename(file_chooser);
+    if (!filename_path) {
+        return; // Brak wybranego pliku
     }
 
-    snprintf(dialog_full_title, sizeof(dialog_full_title), "Wybierz plik dla %s", dialog_title_suffix);
+    // Zwolnienie starej ścieżki
+    if (*target_path_variable) {
+        g_free(*target_path_variable);
+    }
+    *target_path_variable = g_strdup(filename_path);
 
-    dialog = gtk_file_chooser_dialog_new(dialog_full_title, parent_window, action,
-                                         "_Anuluj", GTK_RESPONSE_CANCEL,
-                                         "_Otwórz", GTK_RESPONSE_ACCEPT, NULL);
+    // Aktualizacja etykiety przycisku
+    update_button_label(button_to_update, filename_path, config->prefix);
 
-    GtkFileFilter *filter_jp2 = gtk_file_filter_new();
-    gtk_file_filter_set_name(filter_jp2, "Obrazy JP2 (*.jp2)");
-    gtk_file_filter_add_pattern(filter_jp2, "*.jp2");
-    gtk_file_filter_add_pattern(filter_jp2, "*.JP2");
-    gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(dialog), filter_jp2);
+    g_free(filename_path);
+}
 
-    res = gtk_dialog_run(GTK_DIALOG(dialog));
+static void handle_file_selection(GtkWindow* parent_window, const gchar* dialog_title_suffix,
+                                  char** target_path_variable, GtkButton* button_to_update) {
+    const BandConfig* config = get_band_config(dialog_title_suffix);
+
+    char dialog_title[150];
+    snprintf(dialog_title, sizeof(dialog_title), "Wybierz plik dla %s", dialog_title_suffix);
+
+    GtkWidget* dialog = create_file_dialog(parent_window, dialog_title);
+    gint res = gtk_dialog_run(GTK_DIALOG(dialog));
+
     if (res == GTK_RESPONSE_ACCEPT) {
-        char *filename_path = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
-        if (*target_path_variable) {
-            g_free(*target_path_variable);
-        }
-        *target_path_variable = g_strdup(filename_path);
-        // g_print("Wybrano plik dla %s: %s\n", dialog_title_suffix, filename_path); // Mniej gadatliwe
-        const char *short_name = get_short_filename(filename_path);
-        char new_label[256];
-        snprintf(new_label, sizeof(new_label), "%s%s", button_label_prefix, short_name);
-        gtk_button_set_label(button_to_update, new_label);
-        GList *children = gtk_container_get_children(GTK_CONTAINER(button_to_update));
-        if (children != NULL) {
-            GtkWidget *label_widget = GTK_WIDGET(children->data);
-            if (GTK_IS_LABEL(label_widget)) {
-                gtk_label_set_ellipsize(GTK_LABEL(label_widget), PANGO_ELLIPSIZE_END);
-            }
-            g_list_free(children);
-        }
-        g_free(filename_path);
-    } else {
-        if (button_to_update && !(*target_path_variable)) {
-            gtk_button_set_label(button_to_update, default_button_text);
-        }
+        update_file_selection(target_path_variable, button_to_update,
+                             GTK_FILE_CHOOSER(dialog), config);
+    } else if (!(*target_path_variable)) {
+        gtk_button_set_label(button_to_update, config->default_text);
     }
+
     gtk_widget_destroy(dialog);
 }
 
-static void on_load_b04_clicked(GtkWidget *widget, gpointer data) { handle_file_selection(GTK_WINDOW(data), "pasma B04", &path_b04, GTK_BUTTON(widget)); }
-static void on_load_b08_clicked(GtkWidget *widget, gpointer data) { handle_file_selection(GTK_WINDOW(data), "pasma B08", &path_b08, GTK_BUTTON(widget)); }
-static void on_load_b11_clicked(GtkWidget *widget, gpointer data) { handle_file_selection(GTK_WINDOW(data), "pasma B11", &path_b11, GTK_BUTTON(widget)); }
-static void on_load_scl_clicked(GtkWidget *widget, gpointer data) { handle_file_selection(GTK_WINDOW(data), "pasma SCL", &path_scl, GTK_BUTTON(widget)); }
+static void on_load_b04_clicked(GtkWidget* widget, gpointer data)
+{
+    handle_file_selection(GTK_WINDOW(data), "pasma B04", &path_b04, GTK_BUTTON(widget));
+}
+
+static void on_load_b08_clicked(GtkWidget* widget, gpointer data)
+{
+    handle_file_selection(GTK_WINDOW(data), "pasma B08", &path_b08, GTK_BUTTON(widget));
+}
+
+static void on_load_b11_clicked(GtkWidget* widget, gpointer data)
+{
+    handle_file_selection(GTK_WINDOW(data), "pasma B11", &path_b11, GTK_BUTTON(widget));
+}
+
+static void on_load_scl_clicked(GtkWidget* widget, gpointer data)
+{
+    handle_file_selection(GTK_WINDOW(data), "pasma SCL", &path_scl, GTK_BUTTON(widget));
+}
 
 
-static void on_rozpocznij_clicked(GtkWidget *widget, gpointer user_data) {
-    GtkWidget *config_window_widget = GTK_WIDGET(user_data);
-    GtkWindow *parent_gtk_window = GTK_WINDOW(user_data);
+static void on_rozpocznij_clicked(GtkWidget* widget, gpointer user_data)
+{
+    GtkWidget* config_window_widget = GTK_WIDGET(user_data);
+    GtkWindow* parent_gtk_window = GTK_WINDOW(user_data);
 
     g_print("Przycisk 'Rozpocznij' kliknięty.\n");
 
-    if (!path_b04 || !path_b08 || !path_b11 || !path_scl) {
-        GtkWidget *error_dialog = gtk_message_dialog_new(parent_gtk_window, GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE, "Błąd: Nie wszystkie pasma zostały wybrane!\n\nProszę wybrać pliki dla pasm B04, B08, B11 oraz SCL.");
+    if (!path_b04 || !path_b08 || !path_b11 || !path_scl)
+    {
+        GtkWidget* error_dialog = gtk_message_dialog_new(parent_gtk_window, GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                         GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE,
+                                                         "Błąd: Nie wszystkie pasma zostały wybrane!\n\nProszę wybrać pliki dla pasm B04, B08, B11 oraz SCL.");
         gtk_window_set_title(GTK_WINDOW(error_dialog), "Błąd wyboru plików");
         gtk_dialog_run(GTK_DIALOG(error_dialog));
         gtk_widget_destroy(error_dialog);
@@ -174,10 +237,14 @@ static void on_rozpocznij_clicked(GtkWidget *widget, gpointer user_data) {
     }
 
     g_print("\nRozpoczynanie wczytywania danych pasm...\n");
-    float* pafBand4Data = NULL; int nBand4Width = 0, nBand4Height = 0;
-    float* pafBand8Data = NULL; int nBand8Width = 0, nBand8Height = 0;
-    float* pafBand11Data = NULL; int nBand11Width = 0, nBand11Height = 0;
-    float* pafSCLData = NULL; int nSCLWidth = 0, nSCLHeight = 0;
+    float* pafBand4Data = NULL;
+    int nBand4Width = 0, nBand4Height = 0;
+    float* pafBand8Data = NULL;
+    int nBand8Width = 0, nBand8Height = 0;
+    float* pafBand11Data = NULL;
+    int nBand11Width = 0, nBand11Height = 0;
+    float* pafSCLData = NULL;
+    int nSCLWidth = 0, nSCLHeight = 0;
 
     float* pafBand4Processed = NULL;
     float* pafBand8Processed = NULL;
@@ -186,77 +253,132 @@ static void on_rozpocznij_clicked(GtkWidget *widget, gpointer user_data) {
 
     float* ndvi_result = NULL;
     float* ndmi_result = NULL;
-    IndexMapData *map_display_data = NULL;
+    IndexMapData* map_display_data = NULL;
 
     int final_processing_width;
     int final_processing_height;
 
     pafBand4Data = LoadBandData(path_b04, &nBand4Width, &nBand4Height);
-    if(!pafBand4Data) { fprintf(stderr, "Błąd wczytywania B04!\n"); goto cleanup_processing_error; }
+    if (!pafBand4Data)
+    {
+        fprintf(stderr, "Błąd wczytywania B04!\n");
+        goto cleanup_processing_error;
+    }
     pafBand4Processed = pafBand4Data;
 
     pafBand8Data = LoadBandData(path_b08, &nBand8Width, &nBand8Height);
-    if(!pafBand8Data) { fprintf(stderr, "Błąd wczytywania B08!\n"); goto cleanup_processing_error; }
+    if (!pafBand8Data)
+    {
+        fprintf(stderr, "Błąd wczytywania B08!\n");
+        goto cleanup_processing_error;
+    }
     pafBand8Processed = pafBand8Data;
 
     pafBand11Data = LoadBandData(path_b11, &nBand11Width, &nBand11Height);
-    if(!pafBand11Data) { fprintf(stderr, "Błąd wczytywania B11!\n"); goto cleanup_processing_error; }
+    if (!pafBand11Data)
+    {
+        fprintf(stderr, "Błąd wczytywania B11!\n");
+        goto cleanup_processing_error;
+    }
     pafBand11Processed = pafBand11Data;
 
     pafSCLData = LoadBandData(path_scl, &nSCLWidth, &nSCLHeight);
-    if(!pafSCLData) { fprintf(stderr, "Błąd wczytywania SCL!\n"); goto cleanup_processing_error; }
+    if (!pafSCLData)
+    {
+        fprintf(stderr, "Błąd wczytywania SCL!\n");
+        goto cleanup_processing_error;
+    }
     pafSCLProcessed = pafSCLData;
 
     // g_print("Wszystkie wymagane pasma wczytane pomyślnie.\n"); // Mniej gadatliwe
 
-    if (res_10m_selected) {
+    if (res_10m_selected)
+    {
         final_processing_width = nBand4Width;
         final_processing_height = nBand4Height;
         // g_print("Docelowa rozdzielczość: 10m (%dx%d)\n", final_processing_width, final_processing_height);
 
-        if (nBand11Width != final_processing_width || nBand11Height != final_processing_height) {
+        if (nBand11Width != final_processing_width || nBand11Height != final_processing_height)
+        {
             // g_print("Upsampling B11 do %dx%d...\n", final_processing_width, final_processing_height);
-            float* resampled_b11 = bilinear_resample_float(pafBand11Data, nBand11Width, nBand11Height, final_processing_width, final_processing_height);
-            if (resampled_b11) {
-                if (pafBand11Processed == pafBand11Data) { free(pafBand11Data); } else { free(pafBand11Processed); }
+            float* resampled_b11 = bilinear_resample_float(pafBand11Data, nBand11Width, nBand11Height,
+                                                           final_processing_width, final_processing_height);
+            if (resampled_b11)
+            {
+                if (pafBand11Processed == pafBand11Data) { free(pafBand11Data); }
+                else { free(pafBand11Processed); }
                 pafBand11Data = NULL;
                 pafBand11Processed = resampled_b11;
                 // g_print("Upsampling B11 zakończony.\n");
-            } else { fprintf(stderr, "Błąd upsamplingu B11.\n"); goto cleanup_processing_error; }
+            }
+            else
+            {
+                fprintf(stderr, "Błąd upsamplingu B11.\n");
+                goto cleanup_processing_error;
+            }
         }
-        if (nSCLWidth != final_processing_width || nSCLHeight != final_processing_height) {
+        if (nSCLWidth != final_processing_width || nSCLHeight != final_processing_height)
+        {
             // g_print("Upsampling SCL do %dx%d...\n", final_processing_width, final_processing_height);
-            float* resampled_scl = nearest_neighbor_resample_scl(pafSCLData, nSCLWidth, nSCLHeight, final_processing_width, final_processing_height);
-            if (resampled_scl) {
-                if (pafSCLProcessed == pafSCLData) { free(pafSCLData); } else { free(pafSCLProcessed); }
+            float* resampled_scl = nearest_neighbor_resample_scl(pafSCLData, nSCLWidth, nSCLHeight,
+                                                                 final_processing_width, final_processing_height);
+            if (resampled_scl)
+            {
+                if (pafSCLProcessed == pafSCLData) { free(pafSCLData); }
+                else { free(pafSCLProcessed); }
                 pafSCLData = NULL;
                 pafSCLProcessed = resampled_scl;
                 // g_print("Upsampling SCL zakończony.\n");
-            } else { fprintf(stderr, "Błąd upsamplingu SCL.\n"); goto cleanup_processing_error; }
+            }
+            else
+            {
+                fprintf(stderr, "Błąd upsamplingu SCL.\n");
+                goto cleanup_processing_error;
+            }
         }
-    } else {
+    }
+    else
+    {
         final_processing_width = nBand11Width;
         final_processing_height = nBand11Height;
         // g_print("Docelowa rozdzielczość: 20m (%dx%d)\n", final_processing_width, final_processing_height);
-        if (nBand4Width != final_processing_width || nBand4Height != final_processing_height) {
+        if (nBand4Width != final_processing_width || nBand4Height != final_processing_height)
+        {
             // g_print("Downsampling B04 do %dx%d...\n", final_processing_width, final_processing_height);
-            float* resampled_b04 = average_resample_float(pafBand4Data, nBand4Width, nBand4Height, final_processing_width, final_processing_height);
-            if (resampled_b04) {
-                if (pafBand4Processed == pafBand4Data) { free(pafBand4Data); } else { free(pafBand4Processed); }
+            float* resampled_b04 = average_resample_float(pafBand4Data, nBand4Width, nBand4Height,
+                                                          final_processing_width, final_processing_height);
+            if (resampled_b04)
+            {
+                if (pafBand4Processed == pafBand4Data) { free(pafBand4Data); }
+                else { free(pafBand4Processed); }
                 pafBand4Data = NULL;
                 pafBand4Processed = resampled_b04;
                 // g_print("Downsampling B04 zakończony.\n");
-            } else { fprintf(stderr, "Błąd downsamplingu B04.\n"); goto cleanup_processing_error; }
+            }
+            else
+            {
+                fprintf(stderr, "Błąd downsamplingu B04.\n");
+                goto cleanup_processing_error;
+            }
         }
-        if (nBand8Width != final_processing_width || nBand8Height != final_processing_height) {
+        if (nBand8Width != final_processing_width || nBand8Height != final_processing_height)
+        {
             // g_print("Downsampling B08 do %dx%d...\n", final_processing_width, final_processing_height);
-            float* resampled_b08 = average_resample_float(pafBand8Data, nBand8Width, nBand8Height, final_processing_width, final_processing_height);
-            if (resampled_b08) {
-                if (pafBand8Processed == pafBand8Data) { free(pafBand8Data); } else { free(pafBand8Processed); }
+            float* resampled_b08 = average_resample_float(pafBand8Data, nBand8Width, nBand8Height,
+                                                          final_processing_width, final_processing_height);
+            if (resampled_b08)
+            {
+                if (pafBand8Processed == pafBand8Data) { free(pafBand8Data); }
+                else { free(pafBand8Processed); }
                 pafBand8Data = NULL;
                 pafBand8Processed = resampled_b08;
                 // g_print("Downsampling B08 zakończony.\n");
-            } else { fprintf(stderr, "Błąd downsamplingu B08.\n"); goto cleanup_processing_error; }
+            }
+            else
+            {
+                fprintf(stderr, "Błąd downsamplingu B08.\n");
+                goto cleanup_processing_error;
+            }
         }
     }
 
@@ -264,44 +386,73 @@ static void on_rozpocznij_clicked(GtkWidget *widget, gpointer user_data) {
     ndvi_result = calculate_ndvi(pafBand8Processed, pafBand4Processed,
                                  final_processing_width, final_processing_height,
                                  pafSCLProcessed);
-    if (!ndvi_result) { fprintf(stderr, "Błąd podczas obliczania NDVI.\n"); goto cleanup_processing_error; }
+    if (!ndvi_result)
+    {
+        fprintf(stderr, "Błąd podczas obliczania NDVI.\n");
+        goto cleanup_processing_error;
+    }
     // printf("Obliczono NDVI (bufor: %p).\n", (void*)ndvi_result);
 
     ndmi_result = calculate_ndmi(pafBand8Processed, pafBand11Processed,
                                  final_processing_width, final_processing_height,
                                  pafSCLProcessed);
-    if (!ndmi_result) { fprintf(stderr, "Błąd podczas obliczania NDMI.\n"); goto cleanup_processing_error; }
+    if (!ndmi_result)
+    {
+        fprintf(stderr, "Błąd podczas obliczania NDMI.\n");
+        goto cleanup_processing_error;
+    }
     // printf("Obliczono NDMI (bufor: %p).\n", (void*)ndmi_result);
     // g_print("Obliczanie wskaźników zakończone.\n");
 
-    if (pafBand4Processed) { free(pafBand4Processed); pafBand4Processed = NULL; }
-    if (pafBand8Processed) { free(pafBand8Processed); pafBand8Processed = NULL; }
-    if (pafBand11Processed) { free(pafBand11Processed); pafBand11Processed = NULL; }
-    if (pafSCLProcessed) { free(pafSCLProcessed); pafSCLProcessed = NULL; }
+    if (pafBand4Processed)
+    {
+        free(pafBand4Processed);
+        pafBand4Processed = NULL;
+    }
+    if (pafBand8Processed)
+    {
+        free(pafBand8Processed);
+        pafBand8Processed = NULL;
+    }
+    if (pafBand11Processed)
+    {
+        free(pafBand11Processed);
+        pafBand11Processed = NULL;
+    }
+    if (pafSCLProcessed)
+    {
+        free(pafSCLProcessed);
+        pafSCLProcessed = NULL;
+    }
     // g_print("Zwolniono pamięć po przetworzonych pasmach (użytych do obliczenia wskaźników).\n");
 
     // g_print("Przygotowywanie danych do wyświetlenia...\n");
     map_display_data = g_new(IndexMapData, 1);
-    if (!map_display_data) {
+    if (!map_display_data)
+    {
         fprintf(stderr, "Błąd alokacji pamięci dla IndexMapData.\n");
         goto cleanup_processing_error;
     }
 
-    map_display_data->ndvi_data = ndvi_result; ndvi_result = NULL;
-    map_display_data->ndmi_data = ndmi_result; ndmi_result = NULL;
+    map_display_data->ndvi_data = ndvi_result;
+    ndvi_result = NULL;
+    map_display_data->ndmi_data = ndmi_result;
+    ndmi_result = NULL;
     map_display_data->width = final_processing_width;
     map_display_data->height = final_processing_height;
     strcpy(map_display_data->current_map_type, "NDVI");
 
-    GtkApplication *app = gtk_window_get_application(GTK_WINDOW(config_window_widget));
-    create_and_show_map_window(app, map_display_data); map_display_data = NULL;
+    GtkApplication* app = gtk_window_get_application(GTK_WINDOW(config_window_widget));
+    create_and_show_map_window(app, map_display_data);
+    map_display_data = NULL;
 
     // Nie niszczymy config_window_widget tutaj, jeśli the_config_window go śledzi.
     // Zamiast tego, on_map_window_delete_event_manual_cleanup aktywuje aplikację,
     // a activate_config_window pokaże istniejące the_config_window.
     // Jeśli config_window_widget ma być jednorazowe, to gtk_widget_destroy jest OK.
     // Dla tego przepływu, config_window jest niszczone, a nowe tworzone/pokazywane przez activate.
-    if (config_window_widget == the_config_window) {
+    if (config_window_widget == the_config_window)
+    {
         // Jeśli to jest to samo okno, które śledzimy globalnie, nie niszczymy go tutaj,
         // bo chcemy do niego wrócić. Zostanie zniszczone, gdy użytkownik je zamknie.
         // Jednak activate_config_window i tak stworzy nowe, jeśli the_config_window jest NULL.
@@ -309,26 +460,47 @@ static void on_rozpocznij_clicked(GtkWidget *widget, gpointer user_data) {
         g_print("Niszczenie starego okna konfiguracji po utworzeniu mapy.\n");
         gtk_widget_destroy(config_window_widget);
         // the_config_window zostanie ustawione na NULL przez on_config_window_destroy
-    } else {
-         gtk_widget_destroy(config_window_widget); // Jeśli to nie jest śledzone okno
+    }
+    else
+    {
+        gtk_widget_destroy(config_window_widget); // Jeśli to nie jest śledzone okno
     }
     return;
 
 cleanup_processing_error:
     g_print("Wystąpił błąd w on_rozpocznij_clicked, zwalnianie zasobów...\n");
-    if (ndvi_result) { free(ndvi_result); ndvi_result = NULL; }
-    if (ndmi_result) { free(ndmi_result); ndmi_result = NULL; }
-    if (map_display_data) { free_index_map_data(map_display_data); map_display_data = NULL; }
+    if (ndvi_result)
+    {
+        free(ndvi_result);
+        ndvi_result = NULL;
+    }
+    if (ndmi_result)
+    {
+        free(ndmi_result);
+        ndmi_result = NULL;
+    }
+    if (map_display_data)
+    {
+        free_index_map_data(map_display_data);
+        map_display_data = NULL;
+    }
 
-    if (pafBand4Processed) free(pafBand4Processed); else if(pafBand4Data) free(pafBand4Data);
-    if (pafBand8Processed) free(pafBand8Processed); else if(pafBand8Data) free(pafBand8Data);
-    if (pafBand11Processed) free(pafBand11Processed); else if(pafBand11Data) free(pafBand11Data);
-    if (pafSCLProcessed) free(pafSCLProcessed); else if(pafSCLData) free(pafSCLData);
-    pafBand4Data=pafBand8Data=pafBand11Data=pafSCLData=NULL;
-    pafBand4Processed=pafBand8Processed=pafBand11Processed=pafSCLProcessed=NULL;
+    if (pafBand4Processed) free(pafBand4Processed);
+    else if (pafBand4Data) free(pafBand4Data);
+    if (pafBand8Processed) free(pafBand8Processed);
+    else if (pafBand8Data) free(pafBand8Data);
+    if (pafBand11Processed) free(pafBand11Processed);
+    else if (pafBand11Data) free(pafBand11Data);
+    if (pafSCLProcessed) free(pafSCLProcessed);
+    else if (pafSCLData) free(pafSCLData);
+    pafBand4Data = pafBand8Data = pafBand11Data = pafSCLData = NULL;
+    pafBand4Processed = pafBand8Processed = pafBand11Processed = pafSCLProcessed = NULL;
 
-    if (GTK_IS_WINDOW(parent_gtk_window) && gtk_widget_get_visible(GTK_WIDGET(parent_gtk_window))) {
-        GtkWidget *processing_error_dialog = gtk_message_dialog_new(parent_gtk_window, GTK_DIALOG_DESTROY_WITH_PARENT, GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE, "Błąd podczas przetwarzania danych. Sprawdź konsolę.");
+    if (GTK_IS_WINDOW(parent_gtk_window) && gtk_widget_get_visible(GTK_WIDGET(parent_gtk_window)))
+    {
+        GtkWidget* processing_error_dialog = gtk_message_dialog_new(parent_gtk_window, GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                                    GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE,
+                                                                    "Błąd podczas przetwarzania danych. Sprawdź konsolę.");
         gtk_window_set_title(GTK_WINDOW(processing_error_dialog), "Błąd przetwarzania");
         gtk_dialog_run(GTK_DIALOG(processing_error_dialog));
         gtk_widget_destroy(processing_error_dialog);
@@ -336,70 +508,91 @@ cleanup_processing_error:
     return;
 }
 
-static void on_config_radio_resolution_toggled(GtkToggleButton *togglebutton, gpointer data) {
-    if (gtk_toggle_button_get_active(togglebutton)) {
-        const gchar *label = gtk_button_get_label(GTK_BUTTON(togglebutton));
+static void on_config_radio_resolution_toggled(GtkToggleButton* togglebutton, gpointer data)
+{
+    if (gtk_toggle_button_get_active(togglebutton))
+    {
+        const gchar* label = gtk_button_get_label(GTK_BUTTON(togglebutton));
         if (g_str_has_prefix(label, "upscaling")) { res_10m_selected = TRUE; }
         else if (g_str_has_prefix(label, "downscaling")) { res_10m_selected = FALSE; }
         // g_print("Wybrano rozdzielczość (konfiguracja): %s\n", res_10m_selected ? "10m" : "20m");
     }
 }
 
-static void on_map_type_radio_toggled(GtkToggleButton *togglebutton, gpointer user_data) {
-    if (gtk_toggle_button_get_active(togglebutton)) {
-        GtkWidget *drawing_area = GTK_WIDGET(user_data);
-        IndexMapData *map_data = (IndexMapData*)g_object_get_data(G_OBJECT(drawing_area), "map_data_ptr");
-        if (!map_data) {
+static void on_map_type_radio_toggled(GtkToggleButton* togglebutton, gpointer user_data)
+{
+    if (gtk_toggle_button_get_active(togglebutton))
+    {
+        GtkWidget* drawing_area = GTK_WIDGET(user_data);
+        IndexMapData* map_data = (IndexMapData*)g_object_get_data(G_OBJECT(drawing_area), "map_data_ptr");
+        if (!map_data)
+        {
             g_warning("on_map_type_radio_toggled: map_data jest NULL dla drawing_area.");
             return;
         }
-        const gchar *label = gtk_button_get_label(GTK_BUTTON(togglebutton));
+        const gchar* label = gtk_button_get_label(GTK_BUTTON(togglebutton));
         if (g_strcmp0(label, "NDVI") == 0) { strcpy(map_data->current_map_type, "NDVI"); }
         else if (g_strcmp0(label, "NDMI") == 0) { strcpy(map_data->current_map_type, "NDMI"); }
         // g_print("Wybrano typ mapy do wyświetlenia: %s\n", map_data->current_map_type);
-        if (GTK_IS_WIDGET(drawing_area) && gtk_widget_get_realized(drawing_area) && gtk_widget_get_visible(drawing_area)) {
+        if (GTK_IS_WIDGET(drawing_area) && gtk_widget_get_realized(drawing_area) &&
+            gtk_widget_get_visible(drawing_area))
+        {
             gtk_widget_queue_draw(drawing_area);
         }
     }
 }
 
 // Funkcja pomocnicza do odroczonego niszczenia widgetu
-static gboolean destroy_widget_idle(gpointer data) {
-    GtkWidget *widget_to_destroy = GTK_WIDGET(data);
+static gboolean destroy_widget_idle(gpointer data)
+{
+    GtkWidget* widget_to_destroy = GTK_WIDGET(data);
     // Sprawdź, czy widget nadal istnieje i jest widgetem GTK
     // gtk_widget_in_destruction sprawdza, czy widget jest już w trakcie niszczenia
-    if (widget_to_destroy && GTK_IS_WIDGET(widget_to_destroy) && !gtk_widget_in_destruction(widget_to_destroy)) {
+    if (widget_to_destroy && GTK_IS_WIDGET(widget_to_destroy) && !gtk_widget_in_destruction(widget_to_destroy))
+    {
         g_print("destroy_widget_idle: Niszczenie widgetu %p (odroczone).\n", (void*)widget_to_destroy);
         gtk_widget_destroy(widget_to_destroy);
-    } else {
-        g_print("destroy_widget_idle: Widget %p już zniszczony, w trakcie niszczenia lub nie jest widgetem. Nie niszczę ponownie.\n", (void*)widget_to_destroy);
+    }
+    else
+    {
+        g_print(
+            "destroy_widget_idle: Widget %p już zniszczony, w trakcie niszczenia lub nie jest widgetem. Nie niszczę ponownie.\n",
+            (void*)widget_to_destroy);
     }
     g_object_unref(widget_to_destroy); // Zwolnij referencję dodaną dla g_idle_add
     return G_SOURCE_REMOVE; // Usuń źródło bezczynności po wykonaniu
 }
 
 
-static gboolean on_map_window_delete_event_manual_cleanup(GtkWidget *widget, GdkEvent *event, gpointer user_data) {
+static gboolean on_map_window_delete_event_manual_cleanup(GtkWidget* widget, GdkEvent* event, gpointer user_data)
+{
     g_print("== on_map_window_delete_event_manual_cleanup: Rozpoczęto obsługę zamknięcia okna mapy przez 'x' ==\n");
-    MapWindowCloseAndCleanupData *cleanup_data = (MapWindowCloseAndCleanupData*)user_data;
+    MapWindowCloseAndCleanupData* cleanup_data = (MapWindowCloseAndCleanupData*)user_data;
 
-    if (!cleanup_data) {
+    if (!cleanup_data)
+    {
         g_warning("on_map_window_delete_event_manual_cleanup: cleanup_data jest NULL!");
         return TRUE;
     }
 
     // 1. Upewnij się, że drawing_area nie będzie już próbowało używać map_data.
-    GtkWidget *toplevel = gtk_widget_get_toplevel(widget); // widget to okno mapy
-    if (GTK_IS_WINDOW(toplevel)) {
-        GtkWidget *main_vbox = gtk_bin_get_child(GTK_BIN(toplevel));
-        if (main_vbox && GTK_IS_BOX(main_vbox)) {
-            GList *children = gtk_container_get_children(GTK_CONTAINER(main_vbox));
-            for (GList *iter = children; iter != NULL; iter = g_list_next(iter)) {
-                GtkWidget *child_widget = GTK_WIDGET(iter->data);
-                if (GTK_IS_SCROLLED_WINDOW(child_widget)) {
-                    GtkWidget *drawing_area_map = gtk_bin_get_child(GTK_BIN(child_widget));
-                    if (drawing_area_map && GTK_IS_DRAWING_AREA(drawing_area_map)) {
-                        g_print("on_map_window_delete_event_manual_cleanup: Usuwanie map_data_ptr z drawing_area %p\n", (void*)drawing_area_map);
+    GtkWidget* toplevel = gtk_widget_get_toplevel(widget); // widget to okno mapy
+    if (GTK_IS_WINDOW(toplevel))
+    {
+        GtkWidget* main_vbox = gtk_bin_get_child(GTK_BIN(toplevel));
+        if (main_vbox && GTK_IS_BOX(main_vbox))
+        {
+            GList* children = gtk_container_get_children(GTK_CONTAINER(main_vbox));
+            for (GList* iter = children; iter != NULL; iter = g_list_next(iter))
+            {
+                GtkWidget* child_widget = GTK_WIDGET(iter->data);
+                if (GTK_IS_SCROLLED_WINDOW(child_widget))
+                {
+                    GtkWidget* drawing_area_map = gtk_bin_get_child(GTK_BIN(child_widget));
+                    if (drawing_area_map && GTK_IS_DRAWING_AREA(drawing_area_map))
+                    {
+                        g_print("on_map_window_delete_event_manual_cleanup: Usuwanie map_data_ptr z drawing_area %p\n",
+                                (void*)drawing_area_map);
                         g_object_set_data(G_OBJECT(drawing_area_map), "map_data_ptr", NULL);
                         break;
                     }
@@ -410,16 +603,21 @@ static gboolean on_map_window_delete_event_manual_cleanup(GtkWidget *widget, Gdk
     }
 
     // 2. Zwolnij dane mapy
-    if (cleanup_data->map_data_to_free) {
-        g_print("on_map_window_delete_event_manual_cleanup: Wywoływanie free_index_map_data dla %p.\n", (void*)cleanup_data->map_data_to_free);
+    if (cleanup_data->map_data_to_free)
+    {
+        g_print("on_map_window_delete_event_manual_cleanup: Wywoływanie free_index_map_data dla %p.\n",
+                (void*)cleanup_data->map_data_to_free);
         free_index_map_data(cleanup_data->map_data_to_free);
         cleanup_data->map_data_to_free = NULL;
-    } else {
+    }
+    else
+    {
         g_print("on_map_window_delete_event_manual_cleanup: map_data_to_free był już NULL.\n");
     }
 
     // 3. Reaktywuj aplikację (aby pokazać okno konfiguracji)
-    if (cleanup_data->app) {
+    if (cleanup_data->app)
+    {
         g_print("on_map_window_delete_event_manual_cleanup: Ponowna aktywacja aplikacji.\n");
         g_application_activate(G_APPLICATION(cleanup_data->app));
     }
@@ -431,7 +629,8 @@ static gboolean on_map_window_delete_event_manual_cleanup(GtkWidget *widget, Gdk
                                          cleanup_data);
 
     // 5. ODROCZONE zniszczenie okna mapy
-    g_print("on_map_window_delete_event_manual_cleanup: Kolejkowanie zniszczenia okna mapy %p przez g_idle_add.\n", (void*)widget);
+    g_print("on_map_window_delete_event_manual_cleanup: Kolejkowanie zniszczenia okna mapy %p przez g_idle_add.\n",
+            (void*)widget);
     g_object_ref(widget); // Dodaj referencję, bo widget będzie użyty w idle callback
     g_idle_add(destroy_widget_idle, widget);
 
@@ -445,38 +644,42 @@ static gboolean on_map_window_delete_event_manual_cleanup(GtkWidget *widget, Gdk
 }
 
 
-static void create_and_show_map_window(GtkApplication *app, gpointer user_data) {
-    IndexMapData *passed_map_data = (IndexMapData*)user_data;
+static void create_and_show_map_window(GtkApplication* app, gpointer user_data)
+{
+    IndexMapData* passed_map_data = (IndexMapData*)user_data;
 
-    if (passed_map_data == NULL) {
+    if (passed_map_data == NULL)
+    {
         fprintf(stderr, "create_and_show_map_window: Otrzymano NULL jako user_data.\n");
         return;
     }
-    if (!passed_map_data->ndvi_data && !passed_map_data->ndmi_data) {
+    if (!passed_map_data->ndvi_data && !passed_map_data->ndmi_data)
+    {
         fprintf(stderr, "create_and_show_map_window: Krytyczny błąd - dane NDVI lub NDMI w map_data są NULL.\n");
         free_index_map_data(passed_map_data);
         return;
     }
 
-    GtkWidget *map_window;
-    GtkWidget *map_main_vbox;
-    GtkWidget *radio_map_hbox;
+    GtkWidget* map_window;
+    GtkWidget* map_main_vbox;
+    GtkWidget* radio_map_hbox;
     GtkWidget *radio_ndmi, *radio_ndvi;
-    GtkWidget *scrolled_window_for_map;
-    GtkWidget *drawing_area_map;
+    GtkWidget* scrolled_window_for_map;
+    GtkWidget* drawing_area_map;
 
     map_window = gtk_application_window_new(app);
     gtk_window_set_title(GTK_WINDOW(map_window), "Wynikowa Mapa Wskaźników");
     gtk_window_set_default_size(GTK_WINDOW(map_window), DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT);
     gtk_container_set_border_width(GTK_CONTAINER(map_window), 10);
 
-    MapWindowCloseAndCleanupData *cleanup_data_for_event = g_new(MapWindowCloseAndCleanupData, 1);
+    MapWindowCloseAndCleanupData* cleanup_data_for_event = g_new(MapWindowCloseAndCleanupData, 1);
     cleanup_data_for_event->app = app;
     cleanup_data_for_event->map_data_to_free = passed_map_data;
 
     g_print("create_and_show_map_window: Podłączanie on_map_window_delete_event_manual_cleanup do 'delete-event'.\n");
     g_print("  map_data_to_free: %p\n", (void*)passed_map_data);
-    g_signal_connect(map_window, "delete-event", G_CALLBACK(on_map_window_delete_event_manual_cleanup), cleanup_data_for_event);
+    g_signal_connect(map_window, "delete-event", G_CALLBACK(on_map_window_delete_event_manual_cleanup),
+                     cleanup_data_for_event);
 
     map_main_vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 10);
     gtk_container_add(GTK_CONTAINER(map_window), map_main_vbox);
@@ -496,14 +699,18 @@ static void create_and_show_map_window(GtkApplication *app, gpointer user_data) 
     gtk_box_pack_start(GTK_BOX(radio_map_hbox), radio_ndvi, FALSE, FALSE, 0);
     g_signal_connect(radio_ndvi, "toggled", G_CALLBACK(on_map_type_radio_toggled), drawing_area_map);
 
-    if (strcmp(passed_map_data->current_map_type, "NDVI") == 0) {
+    if (strcmp(passed_map_data->current_map_type, "NDVI") == 0)
+    {
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(radio_ndvi), TRUE);
-    } else {
+    }
+    else
+    {
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(radio_ndmi), TRUE);
     }
 
     scrolled_window_for_map = gtk_scrolled_window_new(NULL, NULL);
-    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled_window_for_map), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
+    gtk_scrolled_window_set_policy(
+        GTK_SCROLLED_WINDOW(scrolled_window_for_map), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
     gtk_widget_set_hexpand(scrolled_window_for_map, TRUE);
     gtk_widget_set_vexpand(scrolled_window_for_map, TRUE);
     gtk_box_pack_start(GTK_BOX(map_main_vbox), scrolled_window_for_map, TRUE, TRUE, 0);
@@ -520,22 +727,32 @@ static void create_and_show_map_window(GtkApplication *app, gpointer user_data) 
 }
 
 // Handler dla zniszczenia okna konfiguracji
-static void on_config_window_destroy(GtkWidget *widget, gpointer data) {
-    g_print("on_config_window_destroy: Okno konfiguracji %p zniszczone. Ustawiam the_config_window na NULL.\n", (void*)widget);
-    if (the_config_window == widget) {
+static void on_config_window_destroy(GtkWidget* widget, gpointer data)
+{
+    g_print("on_config_window_destroy: Okno konfiguracji %p zniszczone. Ustawiam the_config_window na NULL.\n",
+            (void*)widget);
+    if (the_config_window == widget)
+    {
         the_config_window = NULL;
     }
 }
 
 // ZMODYFIKOWANA activate_config_window z użyciem statycznego wskaźnika
-static void activate_config_window(GtkApplication *app, gpointer user_data) {
-    if (the_config_window) {
-        if (gtk_widget_get_visible(the_config_window)) {
-             g_print("activate_config_window: Okno konfiguracji już istnieje i jest widoczne, prezentuję %p.\n", (void*)the_config_window);
+static void activate_config_window(GtkApplication* app, gpointer user_data)
+{
+    if (the_config_window)
+    {
+        if (gtk_widget_get_visible(the_config_window))
+        {
+            g_print("activate_config_window: Okno konfiguracji już istnieje i jest widoczne, prezentuję %p.\n",
+                    (void*)the_config_window);
             gtk_window_present(GTK_WINDOW(the_config_window));
-        } else {
+        }
+        else
+        {
             // Jeśli okno istnieje, ale nie jest widoczne (np. zostało ukryte), pokaż je
-            g_print("activate_config_window: Okno konfiguracji już istnieje, ale nie jest widoczne, pokazuję %p.\n", (void*)the_config_window);
+            g_print("activate_config_window: Okno konfiguracji już istnieje, ale nie jest widoczne, pokazuję %p.\n",
+                    (void*)the_config_window);
             gtk_widget_show_all(the_config_window);
             gtk_window_present(GTK_WINDOW(the_config_window));
         }
@@ -543,12 +760,12 @@ static void activate_config_window(GtkApplication *app, gpointer user_data) {
     }
 
     g_print("activate_config_window: Tworzenie nowego okna konfiguracji.\n");
-    GtkWidget *config_window_local; // Użyj lokalnej zmiennej
-    GtkWidget *main_vbox;
-    GtkWidget *radio_hbox_config;
-    GtkWidget *load_buttons_hbox;
+    GtkWidget* config_window_local; // Użyj lokalnej zmiennej
+    GtkWidget* main_vbox;
+    GtkWidget* radio_hbox_config;
+    GtkWidget* load_buttons_hbox;
     GtkWidget *radio_10m, *radio_20m;
-    GtkWidget *btn_rozpocznij;
+    GtkWidget* btn_rozpocznij;
 
     config_window_local = gtk_application_window_new(app);
     gtk_window_set_title(GTK_WINDOW(config_window_local), "Konfiguracja Analizy");
@@ -579,23 +796,19 @@ static void activate_config_window(GtkApplication *app, gpointer user_data) {
     gtk_box_set_homogeneous(GTK_BOX(load_buttons_hbox), TRUE);
     gtk_box_pack_start(GTK_BOX(main_vbox), load_buttons_hbox, FALSE, FALSE, 0);
 
-    btn_load_b04_widget = gtk_button_new_with_label("Wczytaj pasmo B04");
-    GList *children_b04 = gtk_container_get_children(GTK_CONTAINER(btn_load_b04_widget)); if (children_b04 != NULL && GTK_IS_LABEL(children_b04->data)) { gtk_label_set_ellipsize(GTK_LABEL(children_b04->data), PANGO_ELLIPSIZE_END); } g_list_free(children_b04);
+    btn_load_b04_widget = create_button_with_ellipsis("Wczytaj pasmo B04");
     g_signal_connect(btn_load_b04_widget, "clicked", G_CALLBACK(on_load_b04_clicked), config_window_local);
     gtk_box_pack_start(GTK_BOX(load_buttons_hbox), btn_load_b04_widget, TRUE, TRUE, 0);
 
-    btn_load_b08_widget = gtk_button_new_with_label("Wczytaj pasmo B08");
-    GList *children_b08 = gtk_container_get_children(GTK_CONTAINER(btn_load_b08_widget)); if (children_b08 != NULL && GTK_IS_LABEL(children_b08->data)) { gtk_label_set_ellipsize(GTK_LABEL(children_b08->data), PANGO_ELLIPSIZE_END); } g_list_free(children_b08);
+    btn_load_b08_widget = create_button_with_ellipsis("Wczytaj pasmo B08");
     g_signal_connect(btn_load_b08_widget, "clicked", G_CALLBACK(on_load_b08_clicked), config_window_local);
     gtk_box_pack_start(GTK_BOX(load_buttons_hbox), btn_load_b08_widget, TRUE, TRUE, 0);
 
-    btn_load_b11_widget = gtk_button_new_with_label("Wczytaj pasmo B11");
-    GList *children_b11 = gtk_container_get_children(GTK_CONTAINER(btn_load_b11_widget)); if (children_b11 != NULL && GTK_IS_LABEL(children_b11->data)) { gtk_label_set_ellipsize(GTK_LABEL(children_b11->data), PANGO_ELLIPSIZE_END); } g_list_free(children_b11);
+    btn_load_b11_widget = create_button_with_ellipsis("Wczytaj pasmo B11");
     g_signal_connect(btn_load_b11_widget, "clicked", G_CALLBACK(on_load_b11_clicked), config_window_local);
     gtk_box_pack_start(GTK_BOX(load_buttons_hbox), btn_load_b11_widget, TRUE, TRUE, 0);
 
-    btn_load_scl_widget = gtk_button_new_with_label("Wczytaj pasmo SCL");
-    GList *children_scl = gtk_container_get_children(GTK_CONTAINER(btn_load_scl_widget)); if (children_scl != NULL && GTK_IS_LABEL(children_scl->data)) { gtk_label_set_ellipsize(GTK_LABEL(children_scl->data), PANGO_ELLIPSIZE_END); } g_list_free(children_scl);
+    btn_load_scl_widget = create_button_with_ellipsis("Wczytaj pasmo SCL");
     g_signal_connect(btn_load_scl_widget, "clicked", G_CALLBACK(on_load_scl_clicked), config_window_local);
     gtk_box_pack_start(GTK_BOX(load_buttons_hbox), btn_load_scl_widget, TRUE, TRUE, 0);
 
@@ -607,10 +820,12 @@ static void activate_config_window(GtkApplication *app, gpointer user_data) {
     gtk_widget_show_all(config_window_local);
 }
 
-static gboolean on_draw_map_area(GtkWidget *widget, cairo_t *cr, gpointer user_data) {
-    IndexMapData *map_data = (IndexMapData*)g_object_get_data(G_OBJECT(widget), "map_data_ptr");
+static gboolean on_draw_map_area(GtkWidget* widget, cairo_t* cr, gpointer user_data)
+{
+    IndexMapData* map_data = (IndexMapData*)g_object_get_data(G_OBJECT(widget), "map_data_ptr");
 
-    if (!map_data) {
+    if (!map_data)
+    {
         fprintf(stderr, "on_draw_map_area: map_data_ptr na drawing_area jest NULL. Rysowanie tła.\n");
         cairo_set_source_rgb(cr, 0.1, 0.1, 0.1);
         cairo_paint(cr);
@@ -618,27 +833,34 @@ static gboolean on_draw_map_area(GtkWidget *widget, cairo_t *cr, gpointer user_d
     }
 
     const float* data_to_render = NULL;
-    if (strcmp(map_data->current_map_type, "NDVI") == 0) {
+    if (strcmp(map_data->current_map_type, "NDVI") == 0)
+    {
         data_to_render = map_data->ndvi_data;
-    } else if (strcmp(map_data->current_map_type, "NDMI") == 0) {
+    }
+    else if (strcmp(map_data->current_map_type, "NDMI") == 0)
+    {
         data_to_render = map_data->ndmi_data;
     }
 
-    if (!data_to_render) {
+    if (!data_to_render)
+    {
         fprintf(stderr, "on_draw_map_area: data_to_render jest NULL dla typu mapy %s.\n", map_data->current_map_type);
         cairo_set_source_rgb(cr, 0.2, 0.2, 0.2);
         cairo_paint(cr);
         return TRUE;
     }
 
-    GdkPixbuf *pixbuf = generate_pixbuf_from_index_data(data_to_render,
+    GdkPixbuf* pixbuf = generate_pixbuf_from_index_data(data_to_render,
                                                         map_data->width,
                                                         map_data->height);
-    if (pixbuf) {
+    if (pixbuf)
+    {
         gdk_cairo_set_source_pixbuf(cr, pixbuf, 0, 0);
         cairo_paint(cr);
         g_object_unref(pixbuf);
-    } else {
+    }
+    else
+    {
         fprintf(stderr, "on_draw_map_area: Nie udało się wygenerować pixbuf.\n");
         cairo_set_source_rgb(cr, 1, 0, 0);
         cairo_paint(cr);
@@ -646,8 +868,9 @@ static gboolean on_draw_map_area(GtkWidget *widget, cairo_t *cr, gpointer user_d
     return TRUE;
 }
 
-int run_gui(int argc, char *argv[]) {
-    GtkApplication *app;
+int run_gui(int argc, char* argv[])
+{
+    GtkApplication* app;
     int status;
 
     GDALAllRegister();

--- a/gui.c
+++ b/gui.c
@@ -57,43 +57,29 @@ static GtkWidget* the_config_window = NULL;
 
 static void free_index_map_data(gpointer data)
 {
-    g_print("== free_index_map_data (WYWOŁANIE MANUALNE): Rozpoczęto zwalnianie danych mapy ==\n");
+    g_print("[%s] Rozpoczęto zwalnianie danych mapy.\n", get_timestamp());
     if (data == NULL)
     {
-        g_print("free_index_map_data: Wskaźnik 'data' jest NULL, kończenie.\n");
+        g_print("[%s] Mapa nie zawiera danych, kończenie.\n", get_timestamp());
         return;
     }
-    IndexMapData* map_data = (IndexMapData*)data;
-    g_print("free_index_map_data: Wskaźnik map_data: %p\n", (void*)map_data);
+
+    IndexMapData* map_data = data;
 
     if (map_data->ndvi_data)
     {
-        g_print("free_index_map_data: Zwalnianie ndvi_data (wskaźnik: %p)...\n", (void*)map_data->ndvi_data);
         free(map_data->ndvi_data);
         map_data->ndvi_data = NULL;
-        g_print("free_index_map_data: Zwolniono ndvi_data.\n");
-    }
-    else
-    {
-        g_print("free_index_map_data: ndvi_data był NULL.\n");
     }
 
     if (map_data->ndmi_data)
     {
-        g_print("free_index_map_data: Zwalnianie ndmi_data (wskaźnik: %p)...\n", (void*)map_data->ndmi_data);
         free(map_data->ndmi_data);
         map_data->ndmi_data = NULL;
-        g_print("free_index_map_data: Zwolniono ndmi_data.\n");
-    }
-    else
-    {
-        g_print("free_index_map_data: ndmi_data był NULL.\n");
     }
 
-    g_print("free_index_map_data: Zwalnianie struktury map_data (wskaźnik: %p) za pomocą g_free()...\n",
-            (void*)map_data);
     g_free(map_data);
-    g_print("== free_index_map_data: Zakończono zwalnianie danych mapy dla wskaźnika %p ==\n", data);
+    g_print("[%s] Zakończono zwalnianie danych mapy.\n", get_timestamp());
 }
 
 // Funkcje obsługi zdarzeń dla przycisków ładowania
@@ -323,12 +309,10 @@ static void on_map_type_radio_toggled(GtkToggleButton* togglebutton, gpointer us
 
 static gboolean on_map_window_delete_event_manual_cleanup(GtkWidget* widget, GdkEvent* event, gpointer user_data)
 {
-    g_print("== on_map_window_delete_event_manual_cleanup: Rozpoczęto obsługę zamknięcia okna mapy przez 'x' ==\n");
     MapWindowCloseAndCleanupData* cleanup_data = (MapWindowCloseAndCleanupData*)user_data;
 
     if (!cleanup_data)
     {
-        g_warning("on_map_window_delete_event_manual_cleanup: cleanup_data jest NULL!");
         return TRUE;
     }
 

--- a/gui.c
+++ b/gui.c
@@ -35,7 +35,7 @@ typedef struct
 
 // Deklaracje wprzód
 static void activate_config_window(GtkApplication* app);
-static gboolean on_draw_map_area(GtkWidget* widget, cairo_t* cr, gpointer user_data);
+static gboolean on_draw_map_area(GtkWidget* widget, cairo_t* cr);
 static void on_config_window_destroy(GtkWidget* widget);
 static GtkWidget* create_map_window(GtkApplication* app, IndexMapData* map_data);
 
@@ -525,31 +525,22 @@ static void activate_config_window(GtkApplication* app)
     gtk_widget_show_all(config_window_local);
 }
 
-static gboolean on_draw_map_area(GtkWidget* widget, cairo_t* cr, gpointer user_data)
+static gboolean on_draw_map_area(GtkWidget* widget, cairo_t* cr)
 {
-    IndexMapData* map_data = (IndexMapData*)g_object_get_data(G_OBJECT(widget), "map_data_ptr");
+    IndexMapData* map_data = g_object_get_data(G_OBJECT(widget), "map_data_ptr");
 
     if (!map_data)
     {
-        fprintf(stderr, "on_draw_map_area: map_data_ptr na drawing_area jest NULL. Rysowanie tła.\n");
+        g_printerr("[%s] Błąd tworzenia mapy --- Brak wskaźnika do danych mapy. Rysowanie tła.\n", get_timestamp());
         cairo_set_source_rgb(cr, 0.1, 0.1, 0.1);
         cairo_paint(cr);
         return TRUE;
     }
 
-    const float* data_to_render = NULL;
-    if (strcmp(map_data->current_map_type, "NDVI") == 0)
-    {
-        data_to_render = map_data->ndvi_data;
-    }
-    else if (strcmp(map_data->current_map_type, "NDMI") == 0)
-    {
-        data_to_render = map_data->ndmi_data;
-    }
-
+    const float* data_to_render = strcmp(map_data->current_map_type, "NDVI") == 0 ? map_data->ndvi_data : map_data->ndmi_data;
     if (!data_to_render)
     {
-        fprintf(stderr, "on_draw_map_area: data_to_render jest NULL dla typu mapy %s.\n", map_data->current_map_type);
+        g_printerr("[%s] Błąd tworzenia mapy --- Brak wskaźnika do mapy %s.\n", get_timestamp(), map_data->current_map_type);
         cairo_set_source_rgb(cr, 0.2, 0.2, 0.2);
         cairo_paint(cr);
         return TRUE;
@@ -566,7 +557,7 @@ static gboolean on_draw_map_area(GtkWidget* widget, cairo_t* cr, gpointer user_d
     }
     else
     {
-        fprintf(stderr, "on_draw_map_area: Nie udało się wygenerować pixbuf.\n");
+        g_printerr("[%s] Błąd tworzenia mapy --- Nie udało się wygenerować pixbuf.\n", get_timestamp());
         cairo_set_source_rgb(cr, 1, 0, 0);
         cairo_paint(cr);
     }

--- a/gui.c
+++ b/gui.c
@@ -175,19 +175,6 @@ static void activate_config_window(GtkApplication* app)
 
 static GtkWidget* create_map_window(GtkApplication* app, IndexMapData* map_data)
 {
-    if (!map_data)
-    {
-        g_printerr("[%s] Błąd tworzenia mapy --- Brak wskaźnika do mapy.\n", get_timestamp());
-        return NULL;
-    }
-
-    if (!map_data->ndvi_data && !map_data->ndmi_data)
-    {
-        g_printerr("[%s] Błąd tworzenia mapy --- Brak danych NDMI / NDVI.\n", get_timestamp());
-        free_index_map_data(map_data);
-        return NULL;
-    }
-
     // Tworzenie okna
     GtkWidget* map_window = gtk_application_window_new(app);
     gtk_window_set_title(GTK_WINDOW(map_window), "Wynikowa Mapa Wskaźników");
@@ -258,26 +245,9 @@ static gboolean on_draw_map_area(GtkWidget* widget, cairo_t* cr)
 {
     IndexMapData* map_data = g_object_get_data(G_OBJECT(widget), "map_data_ptr");
 
-    if (!map_data)
-    {
-        g_printerr("[%s] Błąd tworzenia mapy --- Brak wskaźnika do danych mapy. Rysowanie tła.\n", get_timestamp());
-        cairo_set_source_rgb(cr, 0.1, 0.1, 0.1);
-        cairo_paint(cr);
-        return TRUE;
-    }
-
     const float* data_to_render = strcmp(map_data->current_map_type, "NDVI") == 0
                                       ? map_data->ndvi_data
                                       : map_data->ndmi_data;
-    if (!data_to_render)
-    {
-        g_printerr("[%s] Błąd tworzenia mapy --- Brak wskaźnika do mapy %s.\n", get_timestamp(),
-                   map_data->current_map_type);
-        cairo_set_source_rgb(cr, 0.2, 0.2, 0.2);
-        cairo_paint(cr);
-        return TRUE;
-    }
-
     GdkPixbuf* pixbuf = generate_pixbuf_from_index_data(data_to_render,
                                                         map_data->width,
                                                         map_data->height);

--- a/gui.c
+++ b/gui.c
@@ -521,4 +521,11 @@ static void map_window_data_destroy(gpointer data)
 
     g_free(window_data);
     g_print("[%s] map_window_data_destroy: Cleanup zakończony.\n", get_timestamp());
+
+    // Resetowanie ustawień domyślnych
+    path_b04 = NULL;
+    path_b08 = NULL;
+    path_b11 = NULL;
+    path_scl = NULL;
+    res_10m_selected = TRUE;
 }

--- a/gui.c
+++ b/gui.c
@@ -27,7 +27,8 @@ typedef struct
     char current_map_type[10];
 } IndexMapData;
 
-typedef struct {
+typedef struct
+{
     GtkApplication* app;
     IndexMapData* map_data;
 } MapWindowData;
@@ -103,8 +104,10 @@ static void on_load_scl_clicked(GtkWidget* widget, gpointer data)
 
 static int validate_band_paths(BandData bands[], int band_count, GtkWindow* parent_window)
 {
-    for(int i = 0; i < band_count; i++) {
-        if(!*(bands[i].path)) {
+    for (int i = 0; i < band_count; i++)
+    {
+        if (!*(bands[i].path))
+        {
             GtkWidget* error_dialog = gtk_message_dialog_new(parent_window, GTK_DIALOG_DESTROY_WITH_PARENT,
                                                              GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE,
                                                              "Błąd: Nie wszystkie pasma zostały wybrane!\n\nProszę wybrać pliki dla pasm B04, B08, B11 oraz SCL.");
@@ -120,9 +123,11 @@ static int validate_band_paths(BandData bands[], int band_count, GtkWindow* pare
 static int load_all_bands_data(BandData bands[4])
 {
     // Wczytywanie danych dla wszystkich pasm
-    for(int i = 0; i < 4; i++) {
+    for (int i = 0; i < 4; i++)
+    {
         *(bands[i].raw_data) = LoadBandData(*(bands[i].path), bands[i].width, bands[i].height);
-        if(!*(bands[i].raw_data)) {
+        if (!*(bands[i].raw_data))
+        {
             fprintf(stderr, "Błąd wczytywania %s!\n", bands[i].band_name);
             return -1;
         }
@@ -132,11 +137,15 @@ static int load_all_bands_data(BandData bands[4])
 }
 
 static void get_target_resolution_dimensions(const BandData* bands, bool target_resolution_10m,
-                                           int* width_out, int* height_out) {
-    if (target_resolution_10m) {
+                                             int* width_out, int* height_out)
+{
+    if (target_resolution_10m)
+    {
         *width_out = *bands[B04].width;
         *height_out = *bands[B04].height;
-    } else {
+    }
+    else
+    {
         *width_out = *bands[B11].width;
         *height_out = *bands[B11].height;
     }
@@ -144,46 +153,53 @@ static void get_target_resolution_dimensions(const BandData* bands, bool target_
 
 static void free_band_data(BandData bands[4])
 {
-    for(int i = 0; i < 4; i++) {
-        if(*(bands[i].processed_data)) {
+    for (int i = 0; i < 4; i++)
+    {
+        if (*(bands[i].processed_data))
+        {
             free(*(bands[i].processed_data));
-        } else if(*(bands[i].raw_data)) {
+        }
+        else if (*(bands[i].raw_data))
+        {
             free(*(bands[i].raw_data));
         }
         *(bands[i].raw_data) = NULL;
         *(bands[i].processed_data) = NULL;
     }
-
 }
 
 // Zwraca 0 dla sukcesu i -1 dla błędu
 static int process_bands_and_calculate_indices(BandData bands[4], bool res_10m_selected,
-                                             IndexMapData** out_map_data) {
+                                               IndexMapData** out_map_data)
+{
     float* ndvi_result = NULL;
     float* ndmi_result = NULL;
     IndexMapData* map_display_data = NULL;
     int final_processing_width, final_processing_height;
 
     // Load all bands data
-    if (load_all_bands_data(bands) != 0) {
+    if (load_all_bands_data(bands) != 0)
+    {
         return -1;
     }
 
     // Get target resolution dimensions
     get_target_resolution_dimensions(bands, res_10m_selected,
-                                   &final_processing_width, &final_processing_height);
+                                     &final_processing_width, &final_processing_height);
 
     // Resample bands to target resolution
-    if (resample_all_bands_to_target_resolution(bands, 4, res_10m_selected) != 0) {
+    if (resample_all_bands_to_target_resolution(bands, 4, res_10m_selected) != 0)
+    {
         free_band_data(bands);
         return -1;
     }
 
     // Calculate NDVI
     ndvi_result = calculate_ndvi(*bands[B08].processed_data, *bands[B04].processed_data,
-                                final_processing_width, final_processing_height,
-                                *bands[SCL].processed_data);
-    if (!ndvi_result) {
+                                 final_processing_width, final_processing_height,
+                                 *bands[SCL].processed_data);
+    if (!ndvi_result)
+    {
         g_printerr("[%s] Błąd podczas obliczania NDVI.\n", get_timestamp());
         free_band_data(bands);
         return -1;
@@ -191,9 +207,10 @@ static int process_bands_and_calculate_indices(BandData bands[4], bool res_10m_s
 
     // Calculate NDMI
     ndmi_result = calculate_ndmi(*bands[B08].processed_data, *bands[B11].processed_data,
-                                final_processing_width, final_processing_height,
-                                *bands[SCL].processed_data);
-    if (!ndmi_result) {
+                                 final_processing_width, final_processing_height,
+                                 *bands[SCL].processed_data);
+    if (!ndmi_result)
+    {
         g_printerr("[%s] Błąd podczas obliczania NDMI.\n", get_timestamp());
         free(ndvi_result);
         free_band_data(bands);
@@ -205,7 +222,8 @@ static int process_bands_and_calculate_indices(BandData bands[4], bool res_10m_s
 
     // Prepare display data
     map_display_data = g_new(IndexMapData, 1);
-    if (!map_display_data) {
+    if (!map_display_data)
+    {
         g_printerr("[%s] Błąd alokacji pamięci dla IndexMapData.\n", get_timestamp());
         free(ndvi_result);
         free(ndmi_result);
@@ -222,13 +240,15 @@ static int process_bands_and_calculate_indices(BandData bands[4], bool res_10m_s
     return 0;
 }
 
-static void show_error_dialog(GtkWindow* parent_window, const char* message) {
-    if (GTK_IS_WINDOW(parent_window) && gtk_widget_get_visible(GTK_WIDGET(parent_window))) {
+static void show_error_dialog(GtkWindow* parent_window, const char* message)
+{
+    if (GTK_IS_WINDOW(parent_window) && gtk_widget_get_visible(GTK_WIDGET(parent_window)))
+    {
         GtkWidget* error_dialog = gtk_message_dialog_new(parent_window,
-                                                        GTK_DIALOG_DESTROY_WITH_PARENT,
-                                                        GTK_MESSAGE_ERROR,
-                                                        GTK_BUTTONS_CLOSE,
-                                                        "%s", message);
+                                                         GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                         GTK_MESSAGE_ERROR,
+                                                         GTK_BUTTONS_CLOSE,
+                                                         "%s", message);
         gtk_window_set_title(GTK_WINDOW(error_dialog), "Błąd przetwarzania");
         gtk_dialog_run(GTK_DIALOG(error_dialog));
         gtk_widget_destroy(error_dialog);
@@ -251,7 +271,8 @@ static void on_rozpocznij_clicked(GtkWidget* widget, gpointer user_data)
         {&path_scl, &btn_load_scl_widget, &raw_data[3], &processed_data[3], &widths[3], &heights[3], "SCL", 3}
     };
 
-    if (!validate_band_paths(bands, 4, parent_gtk_window)) {
+    if (!validate_band_paths(bands, 4, parent_gtk_window))
+    {
         return;
     }
 
@@ -260,7 +281,8 @@ static void on_rozpocznij_clicked(GtkWidget* widget, gpointer user_data)
     IndexMapData* map_display_data = NULL;
     int processing_result = process_bands_and_calculate_indices(bands, res_10m_selected, &map_display_data);
 
-    if (processing_result != 0) {
+    if (processing_result != 0)
+    {
         g_printerr("[%s] Wystąpił błąd podczas przetwarzania danych.\n", get_timestamp());
         show_error_dialog(parent_gtk_window, "Błąd podczas przetwarzania danych. Sprawdź konsolę.");
         return;
@@ -269,21 +291,23 @@ static void on_rozpocznij_clicked(GtkWidget* widget, gpointer user_data)
     GtkApplication* app = gtk_window_get_application(GTK_WINDOW(config_window_widget));
     GtkWidget* map_window = create_map_window(app, map_display_data);
 
-    if (map_window) {
+    if (map_window)
+    {
         gtk_widget_show_all(map_window);
         gtk_widget_destroy(config_window_widget);
-    } else {
+    }
+    else
+    {
         show_error_dialog(parent_gtk_window, "Błąd podczas tworzenia okna mapy.");
     }
 }
 
-static void on_config_radio_resolution_toggled(GtkToggleButton* togglebutton, gpointer data)
+static void on_config_radio_resolution_toggled(GtkToggleButton* togglebutton)
 {
     if (gtk_toggle_button_get_active(togglebutton))
     {
         const gchar* label = gtk_button_get_label(GTK_BUTTON(togglebutton));
-        if (g_str_has_prefix(label, "upscaling")) { res_10m_selected = TRUE; }
-        else if (g_str_has_prefix(label, "downscaling")) { res_10m_selected = FALSE; }
+        res_10m_selected = g_str_has_prefix(label, "upscaling") ? TRUE : FALSE;
     }
 }
 
@@ -292,15 +316,17 @@ static void on_map_type_radio_toggled(GtkToggleButton* togglebutton, gpointer us
     if (gtk_toggle_button_get_active(togglebutton))
     {
         GtkWidget* drawing_area = GTK_WIDGET(user_data);
-        IndexMapData* map_data = (IndexMapData*)g_object_get_data(G_OBJECT(drawing_area), "map_data_ptr");
-        if (!map_data)
-        {
-            g_warning("on_map_type_radio_toggled: map_data jest NULL dla drawing_area.");
-            return;
-        }
+        IndexMapData* map_data = g_object_get_data(G_OBJECT(drawing_area), "map_data_ptr");
         const gchar* label = gtk_button_get_label(GTK_BUTTON(togglebutton));
-        if (g_strcmp0(label, "NDVI") == 0) { strcpy(map_data->current_map_type, "NDVI"); }
-        else if (g_strcmp0(label, "NDMI") == 0) { strcpy(map_data->current_map_type, "NDMI"); }
+
+        if (g_strcmp0(label, "NDVI") == 0)
+        {
+            strcpy(map_data->current_map_type, "NDVI");
+        }
+        else
+        {
+            strcpy(map_data->current_map_type, "NDMI");
+        }
 
         if (GTK_IS_WIDGET(drawing_area) && gtk_widget_get_realized(drawing_area) &&
             gtk_widget_get_visible(drawing_area))
@@ -316,12 +342,14 @@ static void map_window_data_destroy(gpointer data)
     g_print("[%s] map_window_data_destroy: Rozpoczynanie cleanup.\n", get_timestamp());
 
     MapWindowData* window_data = (MapWindowData*)data;
-    if (!window_data) {
+    if (!window_data)
+    {
         g_print("[%s] window_data jest NULL, pomijam cleanup.\n", get_timestamp());
         return;
     }
 
-    if (window_data->map_data) {
+    if (window_data->map_data)
+    {
         g_print("[%s] Zwalnianie map_data: %p\n", get_timestamp(), (void*)window_data->map_data);
         free_index_map_data(window_data->map_data);
         window_data->map_data = NULL;
@@ -333,12 +361,14 @@ static void map_window_data_destroy(gpointer data)
 
 static GtkWidget* create_map_window(GtkApplication* app, IndexMapData* map_data)
 {
-    if (!map_data) {
+    if (!map_data)
+    {
         g_printerr("create_map_window_v3: map_data jest NULL.\n");
         return NULL;
     }
 
-    if (!map_data->ndvi_data && !map_data->ndmi_data) {
+    if (!map_data->ndvi_data && !map_data->ndmi_data)
+    {
         g_printerr("create_map_window_v3: Brak danych NDVI/NDMI.\n");
         free_index_map_data(map_data);
         return NULL;
@@ -356,11 +386,11 @@ static GtkWidget* create_map_window(GtkApplication* app, IndexMapData* map_data)
     window_data->map_data = map_data;
 
     g_object_set_data_full(G_OBJECT(map_window), "window_data",
-                          window_data, map_window_data_destroy);
+                           window_data, map_window_data_destroy);
 
     // Automatyczna reaktywacja aplikacji przy zamykaniu okna
     g_signal_connect_swapped(map_window, "destroy",
-                           G_CALLBACK(g_application_activate), app);
+                             G_CALLBACK(g_application_activate), app);
 
     // Tworzenie UI
     GtkWidget* main_vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 10);
@@ -389,16 +419,19 @@ static GtkWidget* create_map_window(GtkApplication* app, IndexMapData* map_data)
     g_signal_connect(radio_ndvi, "toggled", G_CALLBACK(on_map_type_radio_toggled), drawing_area);
 
     // Ustawienie domyślnego wyboru
-    if (strcmp(map_data->current_map_type, "NDVI") == 0) {
+    if (strcmp(map_data->current_map_type, "NDVI") == 0)
+    {
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(radio_ndvi), TRUE);
-    } else {
+    }
+    else
+    {
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(radio_ndmi), TRUE);
     }
 
     // Scrolled window dla drawing area
     GtkWidget* scrolled_window = gtk_scrolled_window_new(NULL, NULL);
     gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled_window),
-                                  GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
+                                   GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
     gtk_widget_set_hexpand(scrolled_window, TRUE);
     gtk_widget_set_vexpand(scrolled_window, TRUE);
     gtk_box_pack_start(GTK_BOX(main_vbox), scrolled_window, TRUE, TRUE, 0);

--- a/gui.c
+++ b/gui.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <string.h>
+#include "data_types.h"
 
 #include "gui.h"
 #include "gui_utils.h"

--- a/gui.c
+++ b/gui.c
@@ -359,10 +359,10 @@ static void on_rozpocznij_clicked(GtkWidget* widget, gpointer user_data)
     float* processed_data[4] = {NULL};
 
     BandData bands[4] = {
-        {&path_b04, &raw_data[0], &processed_data[0], &widths[0], &heights[0], "B04", 0},
-        {&path_b08, &raw_data[1], &processed_data[1], &widths[1], &heights[1], "B08", 1},
-        {&path_b11, &raw_data[2], &processed_data[2], &widths[2], &heights[2], "B11", 2},
-        {&path_scl, &raw_data[3], &processed_data[3], &widths[3], &heights[3], "SCL", 3}
+        {&path_b04, &raw_data[0], &processed_data[0], &widths[0], &heights[0], "B04"},
+        {&path_b08, &raw_data[1], &processed_data[1], &widths[1], &heights[1], "B08"},
+        {&path_b11, &raw_data[2], &processed_data[2], &widths[2], &heights[2], "B11"},
+        {&path_scl, &raw_data[3], &processed_data[3], &widths[3], &heights[3], "SCL"}
     };
 
     // Walidacja ścieżek plików

--- a/gui.h
+++ b/gui.h
@@ -5,4 +5,18 @@
 
 int run_gui(int argc, char *argv[]);
 
+typedef struct {
+    const char* suffix;
+    const char* prefix;
+    const char* default_text;
+} BandConfig;
+
+static const BandConfig band_configs[] = {
+    {"pasma B04", "B04: ", "Wczytaj pasmo B04"},
+    {"pasma B08", "B08: ", "Wczytaj pasmo B08"},
+    {"pasma B11", "B11: ", "Wczytaj pasmo B11"},
+    {"pasma SCL", "SCL: ", "Wczytaj pasmo SCL"},
+    {NULL, "Plik: ", "Wybierz plik"} // default
+};
+
 #endif

--- a/gui.h
+++ b/gui.h
@@ -1,22 +1,6 @@
 #ifndef GUI_H
 #define GUI_H
 
-#include <gtk/gtk.h>
-
 int run_gui(int argc, char *argv[]);
-
-typedef struct {
-    const char* suffix;
-    const char* prefix;
-    const char* default_text;
-} BandConfig;
-
-static const BandConfig band_configs[] = {
-    {"pasma B04", "B04: ", "Wczytaj pasmo B04"},
-    {"pasma B08", "B08: ", "Wczytaj pasmo B08"},
-    {"pasma B11", "B11: ", "Wczytaj pasmo B11"},
-    {"pasma SCL", "SCL: ", "Wczytaj pasmo SCL"},
-    {NULL, "Plik: ", "Wybierz plik"} // default
-};
 
 #endif

--- a/gui_utils.c
+++ b/gui_utils.c
@@ -1,0 +1,119 @@
+#include "gui_utils.h"
+#include <pango/pango.h>
+#include <stdio.h>
+
+const BandConfig band_configs[] = {
+    {"pasma B04", "B04: ", "Wczytaj pasmo B04"},
+    {"pasma B08", "B08: ", "Wczytaj pasmo B08"},
+    {"pasma B11", "B11: ", "Wczytaj pasmo B11"},
+    {"pasma SCL", "SCL: ", "Wczytaj pasmo SCL"},
+    {NULL, "Plik: ", "Wybierz plik"} // default
+};
+
+GtkWidget* create_button_with_ellipsis(const char* label) {
+    GtkWidget* button = gtk_button_new_with_label(label);
+    set_button_label_ellipsis(GTK_BUTTON(button));
+    return button;
+}
+
+GtkWidget* create_file_dialog(GtkWindow* parent, const char* title) {
+    GtkWidget* dialog = gtk_file_chooser_dialog_new(
+        title, parent, GTK_FILE_CHOOSER_ACTION_OPEN,
+        "_Anuluj", GTK_RESPONSE_CANCEL,
+        "_Otwórz", GTK_RESPONSE_ACCEPT, NULL);
+
+    // Filtr JP2
+    GtkFileFilter* filter = gtk_file_filter_new();
+    gtk_file_filter_set_name(filter, "Obrazy JP2 (*.jp2)");
+    gtk_file_filter_add_pattern(filter, "*.jp2");
+    gtk_file_filter_add_pattern(filter, "*.JP2");
+    gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(dialog), filter);
+
+    return dialog;
+}
+
+void set_button_label_ellipsis(GtkButton* button) {
+    GList* children = gtk_container_get_children(GTK_CONTAINER(button));
+    if (children != NULL) {
+        GtkWidget* label_widget = GTK_WIDGET(children->data);
+        if (GTK_IS_LABEL(label_widget)) {
+            gtk_label_set_ellipsize(GTK_LABEL(label_widget), PANGO_ELLIPSIZE_END);
+        }
+        g_list_free(children);
+    }
+}
+
+void update_button_label(GtkButton* button, const char* filepath, const char* prefix) {
+    const char* short_name = get_short_filename(filepath);
+
+    char new_label[256];
+    snprintf(new_label, sizeof(new_label), "%s%s", prefix, short_name);
+    gtk_button_set_label(button, new_label);
+
+    // Ustawienie ellipsis dla długich nazw
+    set_button_label_ellipsis(button);
+}
+
+const BandConfig* get_band_config(const gchar* dialog_title_suffix) {
+    for (int i = 0; band_configs[i].suffix != NULL; i++) {
+        if (g_strcmp0(dialog_title_suffix, band_configs[i].suffix) == 0) {
+            return &band_configs[i];
+        }
+    }
+    return &band_configs[4]; // default
+}
+
+void update_file_selection(char** target_path_variable, GtkButton* button_to_update,
+                          GtkFileChooser* file_chooser, const BandConfig* config) {
+    char* filename_path = gtk_file_chooser_get_filename(file_chooser);
+    if (!filename_path) {
+        return; // Brak wybranego pliku
+    }
+
+    // Zwolnienie starej ścieżki
+    if (*target_path_variable) {
+        g_free(*target_path_variable);
+    }
+    *target_path_variable = g_strdup(filename_path);
+
+    // Aktualizacja etykiety przycisku
+    update_button_label(button_to_update, filename_path, config->prefix);
+
+    g_free(filename_path);
+}
+
+void handle_file_selection(GtkWindow* parent_window, const gchar* dialog_title_suffix,
+                          char** target_path_variable, GtkButton* button_to_update) {
+    const BandConfig* config = get_band_config(dialog_title_suffix);
+
+    char dialog_title[150];
+    snprintf(dialog_title, sizeof(dialog_title), "Wybierz plik dla %s", dialog_title_suffix);
+
+    GtkWidget* dialog = create_file_dialog(parent_window, dialog_title);
+    gint res = gtk_dialog_run(GTK_DIALOG(dialog));
+
+    if (res == GTK_RESPONSE_ACCEPT) {
+        update_file_selection(target_path_variable, button_to_update,
+                             GTK_FILE_CHOOSER(dialog), config);
+    } else if (!(*target_path_variable)) {
+        gtk_button_set_label(button_to_update, config->default_text);
+    }
+
+    gtk_widget_destroy(dialog);
+}
+
+gboolean destroy_widget_idle(gpointer data) {
+    GtkWidget* widget_to_destroy = GTK_WIDGET(data);
+    // Sprawdź, czy widget nadal istnieje i jest widgetem GTK
+    // gtk_widget_in_destruction sprawdza, czy widget jest już w trakcie niszczenia
+    if (widget_to_destroy && GTK_IS_WIDGET(widget_to_destroy) && !gtk_widget_in_destruction(widget_to_destroy)) {
+        g_print("destroy_widget_idle: Niszczenie widgetu %p (odroczone).\n", (void*)widget_to_destroy);
+        gtk_widget_destroy(widget_to_destroy);
+    } else {
+        g_print(
+            "destroy_widget_idle: Widget %p już zniszczony, w trakcie niszczenia lub nie jest widgetem. Nie niszczę ponownie.\n",
+            (void*)widget_to_destroy);
+    }
+    g_object_unref(widget_to_destroy); // Zwolnij referencję dodaną dla g_idle_add
+    return G_SOURCE_REMOVE; // Usuń źródło bezczynności po wykonaniu
+}

--- a/gui_utils.c
+++ b/gui_utils.c
@@ -117,3 +117,18 @@ gboolean destroy_widget_idle(gpointer data) {
     g_object_unref(widget_to_destroy); // Zwolnij referencję dodaną dla g_idle_add
     return G_SOURCE_REMOVE; // Usuń źródło bezczynności po wykonaniu
 }
+
+void show_error_dialog(GtkWindow* parent_window, const char* message)
+{
+    if (GTK_IS_WINDOW(parent_window) && gtk_widget_get_visible(GTK_WIDGET(parent_window)))
+    {
+        GtkWidget* error_dialog = gtk_message_dialog_new(parent_window,
+                                                         GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                         GTK_MESSAGE_ERROR,
+                                                         GTK_BUTTONS_CLOSE,
+                                                         "%s", message);
+        gtk_window_set_title(GTK_WINDOW(error_dialog), "Błąd przetwarzania");
+        gtk_dialog_run(GTK_DIALOG(error_dialog));
+        gtk_widget_destroy(error_dialog);
+    }
+}

--- a/gui_utils.c
+++ b/gui_utils.c
@@ -2,14 +2,6 @@
 #include <pango/pango.h>
 #include <stdio.h>
 
-const BandConfig band_configs[] = {
-    {"pasma B04", "B04: ", "Wczytaj pasmo B04"},
-    {"pasma B08", "B08: ", "Wczytaj pasmo B08"},
-    {"pasma B11", "B11: ", "Wczytaj pasmo B11"},
-    {"pasma SCL", "SCL: ", "Wczytaj pasmo SCL"},
-    {NULL, "Plik: ", "Wybierz plik"} // default
-};
-
 GtkWidget* create_button_with_ellipsis(const char* label) {
     GtkWidget* button = gtk_button_new_with_label(label);
     set_button_label_ellipsis(GTK_BUTTON(button));
@@ -52,54 +44,6 @@ void update_button_label(GtkButton* button, const char* filepath, const char* pr
 
     // Ustawienie ellipsis dla długich nazw
     set_button_label_ellipsis(button);
-}
-
-const BandConfig* get_band_config(const gchar* dialog_title_suffix) {
-    for (int i = 0; band_configs[i].suffix != NULL; i++) {
-        if (g_strcmp0(dialog_title_suffix, band_configs[i].suffix) == 0) {
-            return &band_configs[i];
-        }
-    }
-    return &band_configs[4]; // default
-}
-
-void update_file_selection(char** target_path_variable, GtkButton* button_to_update,
-                          GtkFileChooser* file_chooser, const BandConfig* config) {
-    char* filename_path = gtk_file_chooser_get_filename(file_chooser);
-    if (!filename_path) {
-        return; // Brak wybranego pliku
-    }
-
-    // Zwolnienie starej ścieżki
-    if (*target_path_variable) {
-        g_free(*target_path_variable);
-    }
-    *target_path_variable = g_strdup(filename_path);
-
-    // Aktualizacja etykiety przycisku
-    update_button_label(button_to_update, filename_path, config->prefix);
-
-    g_free(filename_path);
-}
-
-void handle_file_selection(GtkWindow* parent_window, const gchar* dialog_title_suffix,
-                          char** target_path_variable, GtkButton* button_to_update) {
-    const BandConfig* config = get_band_config(dialog_title_suffix);
-
-    char dialog_title[150];
-    snprintf(dialog_title, sizeof(dialog_title), "Wybierz plik dla %s", dialog_title_suffix);
-
-    GtkWidget* dialog = create_file_dialog(parent_window, dialog_title);
-    gint res = gtk_dialog_run(GTK_DIALOG(dialog));
-
-    if (res == GTK_RESPONSE_ACCEPT) {
-        update_file_selection(target_path_variable, button_to_update,
-                             GTK_FILE_CHOOSER(dialog), config);
-    } else if (!(*target_path_variable)) {
-        gtk_button_set_label(button_to_update, config->default_text);
-    }
-
-    gtk_widget_destroy(dialog);
 }
 
 gboolean destroy_widget_idle(gpointer data) {

--- a/gui_utils.h
+++ b/gui_utils.h
@@ -4,29 +4,12 @@
 #include <gtk/gtk.h>
 #include "utils.h"
 
-typedef struct {
+typedef struct
+{
     const char* suffix;
     const char* prefix;
     const char* default_text;
 } BandConfig;
-
-typedef struct {
-    char** path;
-    float** raw_data;
-    float** processed_data;
-    int* width;
-    int* height;
-    const char* band_name;
-    int band_index;
-} BandData;
-
-enum BandType
-{
-    B04,
-    B08,
-    B11,
-    SCL
-};
 
 extern const BandConfig band_configs[];
 
@@ -41,9 +24,9 @@ void update_button_label(GtkButton* button, const char* filepath, const char* pr
 // Funkcje pomocnicze dla wyboru plików
 const BandConfig* get_band_config(const gchar* dialog_title_suffix);
 void update_file_selection(char** target_path_variable, GtkButton* button_to_update,
-                          GtkFileChooser* file_chooser, const BandConfig* config);
+                           GtkFileChooser* file_chooser, const BandConfig* config);
 void handle_file_selection(GtkWindow* parent_window, const gchar* dialog_title_suffix,
-                          char** target_path_variable, GtkButton* button_to_update);
+                           char** target_path_variable, GtkButton* button_to_update);
 void show_error_dialog(GtkWindow* parent_window, const char* message);
 
 // Funkcja pomocnicza do odroczonego niszczenia widgetu

--- a/gui_utils.h
+++ b/gui_utils.h
@@ -45,6 +45,7 @@ void update_file_selection(char** target_path_variable, GtkButton* button_to_upd
                           GtkFileChooser* file_chooser, const BandConfig* config);
 void handle_file_selection(GtkWindow* parent_window, const gchar* dialog_title_suffix,
                           char** target_path_variable, GtkButton* button_to_update);
+void show_error_dialog(GtkWindow* parent_window, const char* message);
 
 // Funkcja pomocnicza do odroczonego niszczenia widgetu
 gboolean destroy_widget_idle(gpointer data);

--- a/gui_utils.h
+++ b/gui_utils.h
@@ -12,7 +12,6 @@ typedef struct {
 
 typedef struct {
     char** path;
-    GtkWidget** button;
     float** raw_data;
     float** processed_data;
     int* width;

--- a/gui_utils.h
+++ b/gui_utils.h
@@ -10,6 +10,25 @@ typedef struct {
     const char* default_text;
 } BandConfig;
 
+typedef struct {
+    char** path;
+    GtkWidget** button;
+    float** raw_data;
+    float** processed_data;
+    int* width;
+    int* height;
+    const char* band_name;
+    int band_index;
+} BandData;
+
+enum BandType
+{
+    B04,
+    B08,
+    B11,
+    SCL
+};
+
 extern const BandConfig band_configs[];
 
 // Funkcje do tworzenia i konfigurowania widgetów

--- a/gui_utils.h
+++ b/gui_utils.h
@@ -1,17 +1,14 @@
+/*
+ * Ten plik zawiera implementacje funkcjonalności GUI,
+ * które są przydatne w module GUI. Nie ma tutaj logiki
+ * biznesowej, jedynie funkcje typu "utwórz przycisk"
+ * lub "zmień nagłówek"
+*/
 #ifndef GUI_UTILS_H
 #define GUI_UTILS_H
 
 #include <gtk/gtk.h>
 #include "utils.h"
-
-typedef struct
-{
-    const char* suffix;
-    const char* prefix;
-    const char* default_text;
-} BandConfig;
-
-extern const BandConfig band_configs[];
 
 // Funkcje do tworzenia i konfigurowania widgetów
 GtkWidget* create_button_with_ellipsis(const char* label);
@@ -20,13 +17,6 @@ GtkWidget* create_file_dialog(GtkWindow* parent, const char* title);
 // Funkcje do obsługi przycisków i etykiet
 void set_button_label_ellipsis(GtkButton* button);
 void update_button_label(GtkButton* button, const char* filepath, const char* prefix);
-
-// Funkcje pomocnicze dla wyboru plików
-const BandConfig* get_band_config(const gchar* dialog_title_suffix);
-void update_file_selection(char** target_path_variable, GtkButton* button_to_update,
-                           GtkFileChooser* file_chooser, const BandConfig* config);
-void handle_file_selection(GtkWindow* parent_window, const gchar* dialog_title_suffix,
-                           char** target_path_variable, GtkButton* button_to_update);
 void show_error_dialog(GtkWindow* parent_window, const char* message);
 
 // Funkcja pomocnicza do odroczonego niszczenia widgetu

--- a/gui_utils.h
+++ b/gui_utils.h
@@ -1,0 +1,33 @@
+#ifndef GUI_UTILS_H
+#define GUI_UTILS_H
+
+#include <gtk/gtk.h>
+#include "utils.h"
+
+typedef struct {
+    const char* suffix;
+    const char* prefix;
+    const char* default_text;
+} BandConfig;
+
+extern const BandConfig band_configs[];
+
+// Funkcje do tworzenia i konfigurowania widgetów
+GtkWidget* create_button_with_ellipsis(const char* label);
+GtkWidget* create_file_dialog(GtkWindow* parent, const char* title);
+
+// Funkcje do obsługi przycisków i etykiet
+void set_button_label_ellipsis(GtkButton* button);
+void update_button_label(GtkButton* button, const char* filepath, const char* prefix);
+
+// Funkcje pomocnicze dla wyboru plików
+const BandConfig* get_band_config(const gchar* dialog_title_suffix);
+void update_file_selection(char** target_path_variable, GtkButton* button_to_update,
+                          GtkFileChooser* file_chooser, const BandConfig* config);
+void handle_file_selection(GtkWindow* parent_window, const gchar* dialog_title_suffix,
+                          char** target_path_variable, GtkButton* button_to_update);
+
+// Funkcja pomocnicza do odroczonego niszczenia widgetu
+gboolean destroy_widget_idle(gpointer data);
+
+#endif // GUI_UTILS_H

--- a/index_calculator.c
+++ b/index_calculator.c
@@ -4,6 +4,8 @@
 #include <math.h>   // Dla fabsf
 #include <float.h>  // Dla FLT_EPSILON
 
+#include "utils.h"
+
 // Wartości SCL, które oznaczają piksele do wykluczenia z obliczeń wskaźników
 // 0=NO_DATA, 1=SATURATED_DEFECTIVE, 3=CLOUD_SHADOW, 6=WATER,
 // 8=CLOUD_MEDIUM_PROBABILITY, 9=CLOUD_HIGH_PROBABILITY, 10=THIN_CIRRUS, 11=SNOW_ICE
@@ -24,6 +26,11 @@ static gboolean is_scl_pixel_masked(float scl_value) {
 float* calculate_ndvi(const float* nir_band, const float* red_band,
                       int width, int height,
                       const float* scl_band) {
+    struct timeval start_time, end_time;
+    double elapsed_time;
+    gettimeofday(&start_time, NULL);
+    g_print("[%s] Rozpoczynanie obliczania NDVI.\n", get_timestamp());
+
     if (!nir_band || !red_band || !scl_band || width <= 0 || height <= 0) {
         fprintf(stderr, "Error: Invalid input parameters for calculate_ndvi.\n");
         return NULL;
@@ -56,12 +63,22 @@ float* calculate_ndvi(const float* nir_band, const float* red_band,
             ndvi_data[i] = ndvi_val;
         }
     }
+
+    gettimeofday(&end_time, NULL);
+    elapsed_time = get_time_diff(start_time, end_time);
+    g_print("[%s] Zakończono obliczanie NDVI (czas: %.2fs)\n", get_timestamp(), elapsed_time);
+
     return ndvi_data;
 }
 
 float* calculate_ndmi(const float* nir_band, const float* swir1_band,
                       int width, int height,
                       const float* scl_band) {
+    struct timeval start_time, end_time;
+    double elapsed_time;
+    gettimeofday(&start_time, NULL);
+    g_print("[%s] Rozpoczynanie obliczania NDMI.\n", get_timestamp());
+
     if (!nir_band || !swir1_band || !scl_band || width <= 0 || height <= 0) {
         fprintf(stderr, "Error: Invalid input parameters for calculate_ndmi.\n");
         return NULL;
@@ -94,5 +111,10 @@ float* calculate_ndmi(const float* nir_band, const float* swir1_band,
             ndmi_data[i] = ndmi_val;
         }
     }
+
+    gettimeofday(&end_time, NULL);
+    elapsed_time = get_time_diff(start_time, end_time);
+    g_print("[%s] Zakończono obliczanie NDMI (czas: %.2fs)\n", get_timestamp(), elapsed_time);
+
     return ndmi_data;
 }

--- a/processing_pipeline.c
+++ b/processing_pipeline.c
@@ -1,0 +1,271 @@
+#include "processing_pipeline.h"
+#include "data_loader.h"
+#include "resampler.h"
+#include "index_calculator.h"
+#include "utils.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// ====== GŁÓWNA FUNKCJA ======
+ProcessingResult* process_bands_and_calculate_indices(BandData bands[4], bool target_10m);
+
+// ====== FUNKCJE POMOCNICZE ======
+static int load_all_bands_data(BandData bands[4]);
+static void get_target_resolution_dimensions(const BandData* bands, bool target_10m,
+                                     int* width_out, int* height_out);
+
+// ====== PAMIĘĆ ======
+static void free_processing_result(ProcessingResult* result);
+static void free_band_data(BandData bands[4]);
+
+// ====== WALIDACJA ======
+static int validate_processing_inputs(const BandData bands[4]);
+static int validate_processing_result(const ProcessingResult* result);
+
+ProcessingResult* process_bands_and_calculate_indices(BandData bands[4], bool target_10m)
+{
+    if (!validate_processing_inputs(bands))
+    {
+        fprintf(stderr, "[%s] Błąd walidacji danych wejściowych.\n", get_timestamp());
+        return NULL;
+    }
+
+    ProcessingResult* result = malloc(sizeof(ProcessingResult));
+    if (!result)
+    {
+        fprintf(stderr, "[%s] Błąd alokacji pamięci dla ProcessingResult.\n", get_timestamp());
+        return NULL;
+    }
+
+    // Inicjalizacja wyniku
+    result->ndvi_data = NULL;
+    result->ndmi_data = NULL;
+    result->width = 0;
+    result->height = 0;
+
+    // Ładowanie danych pasm
+    if (load_all_bands_data(bands) != 0)
+    {
+        fprintf(stderr, "[%s] Błąd ładowania danych pasm.\n", get_timestamp());
+        free(result);
+        return NULL;
+    }
+
+    // Określenie docelowych wymiarów
+    get_target_resolution_dimensions(bands, target_10m, &result->width, &result->height);
+
+    // Resampling pasm do docelowej rozdzielczości
+    if (resample_all_bands_to_target_resolution(bands, 4, target_10m) != 0)
+    {
+        fprintf(stderr, "[%s] Błąd resamplingu pasm.\n", get_timestamp());
+        free_band_data(bands);
+        free(result);
+        return NULL;
+    }
+
+    // Obliczanie NDVI
+    result->ndvi_data = calculate_ndvi(*bands[B08].processed_data, *bands[B04].processed_data,
+                                       result->width, result->height,
+                                       *bands[SCL].processed_data);
+    if (!result->ndvi_data)
+    {
+        fprintf(stderr, "[%s] Błąd podczas obliczania NDVI.\n", get_timestamp());
+        free_band_data(bands);
+        free(result);
+        return NULL;
+    }
+
+    // Obliczanie NDMI
+    result->ndmi_data = calculate_ndmi(*bands[B08].processed_data, *bands[B11].processed_data,
+                                       result->width, result->height,
+                                       *bands[SCL].processed_data);
+    if (!result->ndmi_data)
+    {
+        fprintf(stderr, "[%s] Błąd podczas obliczania NDMI.\n", get_timestamp());
+        free(result->ndvi_data);
+        free_band_data(bands);
+        free(result);
+        return NULL;
+    }
+
+    // Zwalnianie danych pasm - już nie potrzebne
+    free_band_data(bands);
+
+    if (!validate_processing_result(result))
+    {
+        fprintf(stderr, "[%s] Błąd walidacji wyników przetwarzania.\n", get_timestamp());
+        free_processing_result(result);
+        return NULL;
+    }
+
+    printf("[%s] Przetwarzanie zakończone pomyślnie. Wymiary: %dx%d\n",
+           get_timestamp(), result->width, result->height);
+
+    return result;
+}
+
+static int load_all_bands_data(BandData bands[4])
+{
+    for (int i = 0; i < 4; i++)
+    {
+        if (!*(bands[i].path) || strlen(*(bands[i].path)) == 0)
+        {
+            fprintf(stderr, "[%s] Błąd: Brak ścieżki dla pasma %s.\n", get_timestamp(), bands[i].band_name);
+            return -1;
+        }
+
+        *(bands[i].raw_data) = LoadBandData(*(bands[i].path), bands[i].width, bands[i].height);
+        if (!*(bands[i].raw_data))
+        {
+            fprintf(stderr, "[%s] Błąd wczytywania pasma %s z pliku: %s\n",
+                    get_timestamp(), bands[i].band_name, *(bands[i].path));
+
+            // Zwolnienie już wczytanych danych
+            for (int j = 0; j < i; j++)
+            {
+                if (*(bands[j].raw_data))
+                {
+                    free(*(bands[j].raw_data));
+                    *(bands[j].raw_data) = NULL;
+                }
+            }
+            return -1;
+        }
+
+        // Ustawienie processed_data na raw_data (początkowo te same dane)
+        *(bands[i].processed_data) = *(bands[i].raw_data);
+
+        printf("[%s] Pomyślnie wczytano pasmo %s (%dx%d pikseli).\n",
+               get_timestamp(), bands[i].band_name, *bands[i].width, *bands[i].height);
+    }
+
+    return 0;
+}
+
+static void get_target_resolution_dimensions(const BandData* bands, bool target_10m,
+                                     int* width_out, int* height_out)
+{
+    if (target_10m)
+    {
+        // Używamy wymiarów pasm 10m (B04, B08)
+        *width_out = *bands[B04].width;
+        *height_out = *bands[B04].height;
+    }
+    else
+    {
+        // Używamy wymiarów pasm 20m (B11, SCL)
+        *width_out = *bands[B11].width;
+        *height_out = *bands[B11].height;
+    }
+
+    printf("[%s] Docelowa rozdzielczość: %dm, wymiary: %dx%d\n",
+           get_timestamp(), target_10m ? 10 : 20, *width_out, *height_out);
+}
+
+static void free_processing_result(ProcessingResult* result)
+{
+    if (!result)
+    {
+        return;
+    }
+
+    if (result->ndvi_data)
+    {
+        free(result->ndvi_data);
+        result->ndvi_data = NULL;
+    }
+
+    if (result->ndmi_data)
+    {
+        free(result->ndmi_data);
+        result->ndmi_data = NULL;
+    }
+
+    free(result);
+    printf("[%s] Zwolniono pamięć ProcessingResult.\n", get_timestamp());
+}
+
+static void free_band_data(BandData bands[4])
+{
+    for (int i = 0; i < 4; i++)
+    {
+        // Zwolnienie processed_data jeśli różni się od raw_data
+        if (*(bands[i].processed_data) && *(bands[i].processed_data) != *(bands[i].raw_data))
+        {
+            free(*(bands[i].processed_data));
+            *(bands[i].processed_data) = NULL;
+        }
+
+        // Zwolnienie raw_data
+        if (*(bands[i].raw_data))
+        {
+            free(*(bands[i].raw_data));
+            *(bands[i].raw_data) = NULL;
+        }
+
+        *(bands[i].processed_data) = NULL;
+    }
+
+    printf("[%s] Zwolniono pamięć danych pasm.\n", get_timestamp());
+}
+
+static int validate_processing_inputs(const BandData bands[4])
+{
+    for (int i = 0; i < 4; i++)
+    {
+        if (!bands[i].path || !*(bands[i].path))
+        {
+            fprintf(stderr, "[%s] Błąd walidacji: Brak ścieżki dla pasma %s.\n",
+                    get_timestamp(), bands[i].band_name);
+            return 0;
+        }
+
+        if (!bands[i].width || !bands[i].height)
+        {
+            fprintf(stderr, "[%s] Błąd walidacji: Brak wskaźników wymiarów dla pasma %s.\n",
+                    get_timestamp(), bands[i].band_name);
+            return 0;
+        }
+
+        if (!bands[i].raw_data || !bands[i].processed_data)
+        {
+            fprintf(stderr, "[%s] Błąd walidacji: Brak wskaźników danych dla pasma %s.\n",
+                    get_timestamp(), bands[i].band_name);
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+static int validate_processing_result(const ProcessingResult* result)
+{
+    if (!result)
+    {
+        fprintf(stderr, "[%s] Błąd walidacji: ProcessingResult jest NULL.\n", get_timestamp());
+        return 0;
+    }
+
+    if (!result->ndvi_data)
+    {
+        fprintf(stderr, "[%s] Błąd walidacji: Brak danych NDVI w wyniku.\n", get_timestamp());
+        return 0;
+    }
+
+    if (!result->ndmi_data)
+    {
+        fprintf(stderr, "[%s] Błąd walidacji: Brak danych NDMI w wyniku.\n", get_timestamp());
+        return 0;
+    }
+
+    if (result->width <= 0 || result->height <= 0)
+    {
+        fprintf(stderr, "[%s] Błąd walidacji: Nieprawidłowe wymiary wyniku: %dx%d.\n",
+                get_timestamp(), result->width, result->height);
+        return 0;
+    }
+
+    return 1;
+}

--- a/processing_pipeline.c
+++ b/processing_pipeline.c
@@ -13,7 +13,6 @@
 ProcessingResult* process_bands_and_calculate_indices(BandData bands[4], bool target_10m);
 
 // ====== FUNKCJE POMOCNICZE ======
-static int load_all_bands_data(BandData bands[4]);
 static void get_target_resolution_dimensions(const BandData* bands, bool target_10m,
                                      int* width_out, int* height_out);
 
@@ -107,43 +106,6 @@ ProcessingResult* process_bands_and_calculate_indices(BandData bands[4], bool ta
     return result;
 }
 
-static int load_all_bands_data(BandData bands[4])
-{
-    for (int i = 0; i < 4; i++)
-    {
-        if (!*(bands[i].path) || strlen(*(bands[i].path)) == 0)
-        {
-            fprintf(stderr, "[%s] Błąd: Brak ścieżki dla pasma %s.\n", get_timestamp(), bands[i].band_name);
-            return -1;
-        }
-
-        *(bands[i].raw_data) = LoadBandData(*(bands[i].path), bands[i].width, bands[i].height);
-        if (!*(bands[i].raw_data))
-        {
-            fprintf(stderr, "[%s] Błąd wczytywania pasma %s z pliku: %s\n",
-                    get_timestamp(), bands[i].band_name, *(bands[i].path));
-
-            // Zwolnienie już wczytanych danych
-            for (int j = 0; j < i; j++)
-            {
-                if (*(bands[j].raw_data))
-                {
-                    free(*(bands[j].raw_data));
-                    *(bands[j].raw_data) = NULL;
-                }
-            }
-            return -1;
-        }
-
-        // Ustawienie processed_data na raw_data (początkowo te same dane)
-        *(bands[i].processed_data) = *(bands[i].raw_data);
-
-        printf("[%s] Pomyślnie wczytano pasmo %s (%dx%d pikseli).\n",
-               get_timestamp(), bands[i].band_name, *bands[i].width, *bands[i].height);
-    }
-
-    return 0;
-}
 
 static void get_target_resolution_dimensions(const BandData* bands, bool target_10m,
                                      int* width_out, int* height_out)

--- a/processing_pipeline.c
+++ b/processing_pipeline.c
@@ -3,6 +3,7 @@
 #include "resampler.h"
 #include "index_calculator.h"
 #include "utils.h"
+#include "data_types.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/processing_pipeline.c
+++ b/processing_pipeline.c
@@ -178,7 +178,7 @@ static int validate_processing_inputs(const BandData bands[4])
 {
     for (int i = 0; i < 4; i++)
     {
-        if (!bands[i].path || !*(bands[i].path))
+        if (!bands[i].path)
         {
             fprintf(stderr, "[%s] Błąd walidacji: Brak ścieżki dla pasma %s.\n",
                     get_timestamp(), bands[i].band_name);

--- a/processing_pipeline.h
+++ b/processing_pipeline.h
@@ -12,6 +12,43 @@ typedef struct
     int height;
 } ProcessingResult;
 
+/**
+ * @brief Główna funkcja pipeline'u przetwarzania danych satelitarnych Sentinel-2
+ *
+ * Funkcja wykonuje kompletny proces przetwarzania danych satelitarnych:
+ * 1. Waliduje dane wejściowe
+ * 2. Wczytuje dane wszystkich pasm (B04, B08, B11, SCL)
+ * 3. Wykonuje resampling do wspólnej rozdzielczości (10m lub 20m)
+ * 4. Oblicza wskaźniki wegetacji NDVI i NDMI z zastosowaniem maski SCL
+ * 5. Waliduje wyniki i zwraca strukturę ProcessingResult
+ *
+ * Pipeline automatycznie zarządza pamięcią - w przypadku błędu na którymkolwiek etapie
+ * zwalnia już zaalokowane zasoby i zwraca NULL.
+ *
+ * @param bands Tablica 4 struktur BandData w określonej kolejności:
+ *              - bands[0] (B04): Pasmo czerwone (RED), rozdzielczość 10m
+ *              - bands[1] (B08): Pasmo bliskiej podczerwieni (NIR), rozdzielczość 10m
+ *              - bands[2] (B11): Pasmo średniej podczerwieni (SWIR1), rozdzielczość 20m
+ *              - bands[3] (SCL): Warstwa klasyfikacji sceny, rozdzielczość 20m
+ *
+ * @param target_10m Flaga określająca docelową rozdzielczość:
+ *                   - true: upscaling do 10m (powiększenie pasm 20m)
+ *                   - false: downscaling do 20m (zmniejszenie pasm 10m)
+ *
+ * @return Wskaźnik do struktury ProcessingResult zawierającej:
+ *         - ndvi_data: Tablica wartości NDVI w zakresie [-1, 1]
+ *         - ndmi_data: Tablica wartości NDMI w zakresie [-1, 1]
+ *         - width, height: Wymiary wynikowych tablic w pikselach
+ *
+ *         NULL w przypadku błędu (szczegóły w stderr)
+ *
+ * @note Zwrócona struktura musi zostać zwolniona przez free_processing_result()
+ * @note Funkcja automatycznie stosuje maskę SCL do wykluczenia nieprawidłowych pikseli
+ * @note Po pomyślnym przetwarzaniu zwalnia pamięć danych pasm (bands)
+ *
+ * @warning Zakłada że tablica bands ma dokładnie 4 elementy w określonej kolejności
+ * @warning Modyfikuje struktury BandData (zwalnia pamięć processed_data i raw_data)
+ */
 ProcessingResult* process_bands_and_calculate_indices(BandData bands[4], bool target_10m);
 
 #endif // PROCESSING_PIPELINE_H

--- a/processing_pipeline.h
+++ b/processing_pipeline.h
@@ -1,0 +1,17 @@
+#ifndef PROCESSING_PIPELINE_H
+#define PROCESSING_PIPELINE_H
+
+#include "gui_utils.h"
+#include <stdbool.h>
+
+typedef struct
+{
+    float* ndvi_data;
+    float* ndmi_data;
+    int width;
+    int height;
+} ProcessingResult;
+
+ProcessingResult* process_bands_and_calculate_indices(BandData bands[4], bool target_10m);
+
+#endif // PROCESSING_PIPELINE_H

--- a/processing_pipeline.h
+++ b/processing_pipeline.h
@@ -1,7 +1,7 @@
 #ifndef PROCESSING_PIPELINE_H
 #define PROCESSING_PIPELINE_H
 
-#include "gui_utils.h"
+#include "data_types.h"
 #include <stdbool.h>
 
 typedef struct

--- a/resampler.c
+++ b/resampler.c
@@ -116,6 +116,24 @@ float* allocate_output_band(size_t num_pixels)
     return output_band;
 }
 
+/**
+ * @brief Przygotowuje zaalokowany bufor dla danych wyjściowych po resamplingu
+ *
+ * Funkcja waliduje parametry wejściowe i wyjściowe, sprawdza poprawność wymiarów,
+ * oblicza wymaganą ilość pamięci i alokuje bufor dla danych po resamplingu.
+ *
+ * @param input_band Wskaźnik do danych wejściowych pasma (tablica float)
+ * @param input_width Szerokość danych wejściowych w pikselach
+ * @param input_height Wysokość danych wejściowych w pikselach
+ * @param output_width Docelowa szerokość po resamplingu w pikselach
+ * @param output_height Docelowa wysokość po resamplingu w pikselach
+ * @param error_suffix Komunikat błędu do wyświetlenia w przypadku niepowodzenia
+ *
+ * @return Wskaźnik do zaalokowanego bufora float o rozmiarze output_width × output_height,
+ *         lub NULL w przypadku błędu walidacji lub alokacji pamięci
+ *
+ * @note W przypadku błędu wypisuje error_suffix na stderr
+ */
 float* prepare_data(
     const float* input_band,
     int input_width,

--- a/resampler.c
+++ b/resampler.c
@@ -3,7 +3,12 @@
 #include <math.h>
 
 #include "resampler.h"
+
+#include <stdint.h>
+#include <glib/gmessages.h>
+
 #include "utils.h"
+#include "data_types.h"
 
 typedef struct
 {

--- a/resampler.c
+++ b/resampler.c
@@ -5,26 +5,94 @@
 #include "resampler.h"
 #include "utils.h"
 
+typedef struct
+{
+    int target_width;
+    int target_height;
+    gboolean is_10m_resolution;
+} ResamplingParams;
+
+// ====== WALIDACJA ======
+int validate_input_params(const float* input_band, int input_width, int input_height, int output_width, int output_height);
+int validate_output_size(int output_width, int output_height, size_t* num_pixels);
+// ====== PAMIĘĆ ======
+float* allocate_output_band(size_t num_pixels);
+float* prepare_data(const float* input_band, int input_width, int input_height, int output_width, int output_height, const char* error_suffix);
+void replace_band_data(BandData* band_data, float* new_data);
+// ====== FUNKCJONALNOŚĆ ======
+int resample_single_band(BandData* band_data, int band_index, const ResamplingParams* params);
+// ====== ALGORYTMY RESAMPLINGU ======
+void perform_nearest_neighbor_resample(const float* input_band, float* output_band, int input_width, int input_height, int output_width, int output_height);
+float* nearest_neighbor_resample_scl(const float* input_band, int input_width, int input_height, int output_width, int output_height);
+void perform_bilinear_resample(const float* input_band, float* output_band, int input_width, int input_height, int output_width, int output_height);
+float* bilinear_resample_float(const float* input_band, int input_width, int input_height, int output_width, int output_height);
+void perform_average_resample(const float* input_band, float* output_band, int input_width, int input_height, int output_width, int output_height);
+float* average_resample_float(const float* input_band, int input_width, int input_height, int output_width, int output_height);
+
+
+int resample_all_bands_to_target_resolution(BandData* bands, int band_count, gboolean target_resolution_10m)
+{
+    // Przygotuj parametry resamplingu
+    ResamplingParams params;
+    params.is_10m_resolution = target_resolution_10m;
+
+    if (target_resolution_10m)
+    {
+        // Docelowa rozdzielczość 10m - używaj wymiarów B04
+        params.target_width = *bands[B04].width;
+        params.target_height = *bands[B04].height;
+    }
+    else
+    {
+        // Docelowa rozdzielczość 20m - używaj wymiarów B11
+        params.target_width = *bands[B11].width;
+        params.target_height = *bands[B11].height;
+    }
+
+    g_print("[%s] Rozpoczynanie resamplingu do rozdzielczości %s.\n",
+            get_timestamp(), target_resolution_10m ? "10m" : "20m");
+
+    // Wykonaj resampling dla każdego pasma
+    for (int i = 0; i < band_count; i++)
+    {
+        if (resample_single_band(&bands[i], i, &params) != 0)
+        {
+            fprintf(stderr, "Błąd podczas resamplingu pasma %s.\n", bands[i].band_name);
+            return -1;
+        }
+    }
+
+    g_print("[%s] Resampling zakończony pomyślnie.\n", get_timestamp());
+    return 0;
+}
+
 int validate_input_params(const float* input_band, int input_width, int input_height,
-                                int output_width, int output_height) {
+                          int output_width, int output_height)
+{
     if (input_band == NULL || input_width <= 0 || input_height <= 0 ||
-        output_width <= 0 || output_height <= 0) {
+        output_width <= 0 || output_height <= 0)
+    {
         fprintf(stderr, "Error: Invalid input parameters");
         return 0;
     }
     return 1;
 }
 
-int validate_output_size(int output_width, int output_height, size_t* num_pixels) {
+int validate_output_size(int output_width, int output_height, size_t* num_pixels)
+{
     *num_pixels = (size_t)output_width * output_height;
 
-    if (*num_pixels == 0) {
-        fprintf(stderr, "Error: Output dimensions result in zero pixels but dimensions are non-zero (potential overflow or invalid args)");
+    if (*num_pixels == 0)
+    {
+        fprintf(
+            stderr,
+            "Error: Output dimensions result in zero pixels but dimensions are non-zero (potential overflow or invalid args)");
         return 0;
     }
 
     // Sprawdzenie, czy malloc nie dostanie zbyt dużej wartości
-    if (*num_pixels > (SIZE_MAX / sizeof(float))) {
+    if (*num_pixels > (SIZE_MAX / sizeof(float)))
+    {
         fprintf(stderr, "Error: Requested memory allocation size is too large");
         return 0;
     }
@@ -32,20 +100,15 @@ int validate_output_size(int output_width, int output_height, size_t* num_pixels
     return 1;
 }
 
-float* allocate_output_band(size_t num_pixels) {
+float* allocate_output_band(size_t num_pixels)
+{
     float* output_band = malloc(num_pixels * sizeof(float));
-    if (output_band == NULL) {
+    if (output_band == NULL)
+    {
         fprintf(stderr, "Error: Memory allocation failed for output band");
         return NULL;
     }
     return output_band;
-}
-
-// Funkcja do zaciskania wartości do zakresu
-int clamp(int value, int min, int max) {
-    if (value < min) return min;
-    if (value > max) return max;
-    return value;
 }
 
 float* prepare_data(
@@ -55,20 +118,24 @@ float* prepare_data(
     int output_width,
     int output_height,
     const char* error_suffix
-) {
-    if (!validate_input_params(input_band, input_width, input_height, output_width, output_height)) {
+)
+{
+    if (!validate_input_params(input_band, input_width, input_height, output_width, output_height))
+    {
         fprintf(stderr, error_suffix);
         return NULL;
     }
 
     size_t num_output_pixels;
-    if (!validate_output_size(output_width, output_height, &num_output_pixels)) {
+    if (!validate_output_size(output_width, output_height, &num_output_pixels))
+    {
         fprintf(stderr, error_suffix);
         return NULL;
     }
 
     float* output_band = allocate_output_band(num_output_pixels);
-    if (output_band == NULL) {
+    if (output_band == NULL)
+    {
         fprintf(stderr, error_suffix);
         return NULL;
     }
@@ -77,13 +144,16 @@ float* prepare_data(
 }
 
 void perform_nearest_neighbor_resample(const float* input_band, float* output_band,
-                                            int input_width, int input_height,
-                                            int output_width, int output_height) {
+                                       int input_width, int input_height,
+                                       int output_width, int output_height)
+{
     float x_ratio = (float)input_width / output_width;
     float y_ratio = (float)input_height / output_height;
 
-    for (int y_out = 0; y_out < output_height; y_out++) {
-        for (int x_out = 0; x_out < output_width; x_out++) {
+    for (int y_out = 0; y_out < output_height; y_out++)
+    {
+        for (int x_out = 0; x_out < output_width; x_out++)
+        {
             // Standardowe mapowanie z zaokrągleniem do najbliższego sąsiada
             int x_in = (int)(x_out * x_ratio + 0.5f);
             int y_in = (int)(y_out * y_ratio + 0.5f);
@@ -104,32 +174,36 @@ float* nearest_neighbor_resample_scl(
     int input_height,
     int output_width,
     int output_height
-) {
+)
+{
     char* error_suffix = "in nearest_neighbor_resample_scl.\n";
 
     float* output_band = prepare_data(
         input_band, input_width, input_height, output_width, output_height, error_suffix);
 
-    if (output_band == NULL) {
+    if (output_band == NULL)
+    {
         return NULL;
     }
 
     perform_nearest_neighbor_resample(input_band, output_band,
-                                     input_width, input_height,
-                                     output_width, output_height);
+                                      input_width, input_height,
+                                      output_width, output_height);
 
     return output_band;
 }
 
 void perform_bilinear_resample(const float* input_band, float* output_band,
-                                     int input_width, int input_height,
-                                     int output_width, int output_height) {
-
+                               int input_width, int input_height,
+                               int output_width, int output_height)
+{
     float x_ratio = (float)input_width / output_width;
     float y_ratio = (float)input_height / output_height;
 
-    for (int y_out = 0; y_out < output_height; y_out++) {
-        for (int x_out = 0; x_out < output_width; x_out++) {
+    for (int y_out = 0; y_out < output_height; y_out++)
+    {
+        for (int x_out = 0; x_out < output_width; x_out++)
+        {
             // Mapowanie środka piksela wyjściowego na siatkę wejściową
             float x_in_proj = (x_out + 0.5f) * x_ratio - 0.5f;
             float y_in_proj = (y_out + 0.5f) * y_ratio - 0.5f;
@@ -174,32 +248,37 @@ float* bilinear_resample_float(
     int input_height,
     int output_width,
     int output_height
-) {
+)
+{
     char* error_suffix = "in bilinear_resample_float.\n";
 
     float* output_band = prepare_data(
         input_band, input_width, input_height, output_width, output_height, error_suffix);
 
-    if (output_band == NULL) {
+    if (output_band == NULL)
+    {
         return NULL;
     }
 
     perform_bilinear_resample(input_band, output_band,
-                             input_width, input_height,
-                             output_width, output_height);
+                              input_width, input_height,
+                              output_width, output_height);
 
     return output_band;
 }
 
 void perform_average_resample(const float* input_band, float* output_band,
-                                    int input_width, int input_height,
-                                    int output_width, int output_height) {
+                              int input_width, int input_height,
+                              int output_width, int output_height)
+{
     // Współczynniki skalowania (ile pikseli wejściowych przypada na jeden piksel wyjściowy)
     float x_scale_factor = (float)input_width / output_width;
     float y_scale_factor = (float)input_height / output_height;
 
-    for (int y_out = 0; y_out < output_height; y_out++) {
-        for (int x_out = 0; x_out < output_width; x_out++) {
+    for (int y_out = 0; y_out < output_height; y_out++)
+    {
+        for (int x_out = 0; x_out < output_width; x_out++)
+        {
             // Początek bloku (lewy górny róg)
             int x_start_in = (int)roundf(x_out * x_scale_factor);
             int y_start_in = (int)roundf(y_out * y_scale_factor);
@@ -219,17 +298,22 @@ void perform_average_resample(const float* input_band, float* output_band,
             int count = 0;
 
             // Sumowanie wartości pikseli
-            for (int y_in = y_start_in; y_in < y_end_in; y_in++) {
-                for (int x_in = x_start_in; x_in < x_end_in; x_in++) {
+            for (int y_in = y_start_in; y_in < y_end_in; y_in++)
+            {
+                for (int x_in = x_start_in; x_in < x_end_in; x_in++)
+                {
                     sum += input_band[pixel_index(x_in, y_in, input_width)];
                     count++;
                 }
             }
 
             // Obliczenie średniej lub fallback do najbliższego sąsiada
-            if (count > 0) {
+            if (count > 0)
+            {
                 output_band[pixel_index(x_out, y_out, output_width)] = sum / count;
-            } else {
+            }
+            else
+            {
                 // Sytuacja awaryjna, nie powinno się zdarzyć przy poprawnym zaciskaniu
                 // Nie pozwalamy na brak przypisania żadnej wartości
                 int center_x_in = (x_start_in + x_end_in - 1) / 2;
@@ -251,24 +335,130 @@ float* average_resample_float(
     int input_height,
     int output_width,
     int output_height
-) {
+)
+{
     char* error_suffix = "in average_resample_float.\n";
 
     float* output_band = prepare_data(
         input_band, input_width, input_height, output_width, output_height, error_suffix);
 
-    if (output_band == NULL) {
+    if (output_band == NULL)
+    {
         return NULL;
     }
 
     // Warning pomiędzy prepare_data a perform_average_resample
-    if (output_width > input_width || output_height > input_height) {
+    if (output_width > input_width || output_height > input_height)
+    {
         fprintf(stderr, "Warning: average_resample_float called for upsampling. Results may be incorrect.\n");
     }
 
     perform_average_resample(input_band, output_band,
-                           input_width, input_height,
-                           output_width, output_height);
+                             input_width, input_height,
+                             output_width, output_height);
 
     return output_band;
+}
+
+void replace_band_data(BandData* band_data, float* new_data)
+{
+    // Zwolnij dane
+    if (*band_data->processed_data != *band_data->raw_data && *band_data->processed_data != NULL)
+    {
+        free(*band_data->processed_data);
+    }
+
+    // Zamień dane
+    *band_data->processed_data = new_data;
+}
+
+int resample_single_band(BandData* band_data, int band_index, const ResamplingParams* params)
+{
+    // Sprawdź czy resampling jest potrzebny
+    if (*band_data->width == params->target_width && *band_data->height == params->target_height)
+    {
+        return 0;
+    }
+
+    float* resampled = NULL;
+    struct timeval start_time, end_time;
+    double elapsed_time;
+
+    if (params->is_10m_resolution)
+    {
+        // Upsampling do 10m rozdzielczości
+        switch (band_index)
+        {
+        case B11:
+            gettimeofday(&start_time, NULL);
+            g_print("[%s] [B11] Rozpoczynam upsampling\n", get_timestamp());
+            resampled = bilinear_resample_float(
+                *band_data->raw_data,
+                *band_data->width,
+                *band_data->height,
+                params->target_width,
+                params->target_height
+            );
+            gettimeofday(&end_time, NULL);
+            elapsed_time = get_time_diff(start_time, end_time);
+            g_print("[%s] [B11] Zakończono upsampling (czas: %.2fs)\n", get_timestamp(), elapsed_time);
+            break;
+
+        case SCL:
+            gettimeofday(&start_time, NULL);
+            g_print("[%s] [SCL] Rozpoczynam upsampling\n", get_timestamp());
+            resampled = nearest_neighbor_resample_scl(
+                *band_data->raw_data,
+                *band_data->width,
+                *band_data->height,
+                params->target_width,
+                params->target_height
+            );
+            gettimeofday(&end_time, NULL);
+            elapsed_time = get_time_diff(start_time, end_time);
+            g_print("[%s] [SCL] Zakończono upsampling (czas: %.2fs)\n", get_timestamp(), elapsed_time);
+            break;
+
+        default:
+            // B04 i B08 już mają rozdzielczość 10m
+            return 0;
+        }
+    }
+    else
+    {
+        // Downsampling do 20m rozdzielczości
+        switch (band_index)
+        {
+        case B04:
+        case B08:
+            // B04 i B08 - averaging downsampling
+            gettimeofday(&start_time, NULL);
+            g_print("[%s] [%s] Rozpoczynam downsampling\n", get_timestamp(), band_data->band_name);
+            resampled = average_resample_float(
+                *band_data->raw_data,
+                *band_data->width,
+                *band_data->height,
+                params->target_width,
+                params->target_height
+            );
+            gettimeofday(&end_time, NULL);
+            elapsed_time = get_time_diff(start_time, end_time);
+            g_print("[%s] [%s] Zakończono downsampling (czas: %.2fs)\n", get_timestamp(), band_data->band_name, elapsed_time);
+            break;
+
+        default:
+            // B11 i SCL już mają rozdzielczość 20m
+            return 0;
+        }
+    }
+
+    if (!resampled)
+    {
+        g_print("[%s] [%s] Błąd resamplingu.\n", get_timestamp(), band_data->band_name);
+        return -1;
+    }
+
+    // Zamień dane na nowe po resamplingu
+    replace_band_data(band_data, resampled);
+    return 0;
 }

--- a/resampler.h
+++ b/resampler.h
@@ -1,32 +1,8 @@
 #ifndef RESAMPLER_H
 #define RESAMPLER_H
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdint.h>
+#include "gui_utils.h"
 
-float* nearest_neighbor_resample_scl(
-    const float* input_band,
-    int input_width,
-    int input_height,
-    int output_width,
-    int output_height
-);
-
-float* bilinear_resample_float(
-    const float* input_band,
-    int input_width,
-    int input_height,
-    int output_width,
-    int output_height
-);
-
-float* average_resample_float(
-    const float* input_band,
-    int input_width,
-    int input_height,
-    int output_width,
-    int output_height
-);
+int resample_all_bands_to_target_resolution(BandData* bands, int band_count, gboolean target_resolution_10m);
 
 #endif

--- a/resampler.h
+++ b/resampler.h
@@ -1,7 +1,10 @@
 #ifndef RESAMPLER_H
 #define RESAMPLER_H
 
-#include "gui_utils.h"
+#include <gtk/gtk.h>
+#include <glib/gtypes.h>
+
+#include "data_types.h"
 
 int resample_all_bands_to_target_resolution(BandData* bands, int band_count, gboolean target_resolution_10m);
 

--- a/utils.c
+++ b/utils.c
@@ -1,16 +1,16 @@
 #include "utils.h"
 #include <string.h>
 #include <stdio.h>
+#include <time.h>
+#include <sys/time.h>
 
 const char* get_short_filename(const char *filepath) {
     if (!filepath) {
         return "(nie wybrano)";
     }
-
     // Wyszukaj ostatnie wystąpienie separatorów ścieżki
     const char *last_slash = strrchr(filepath, '/');
     const char *last_backslash = strrchr(filepath, '\\');
-
     // Jeśli oba separatory istnieją, wybierz ten, który jest dalej (bardziej na prawo)
     if (last_slash && last_backslash) {
         return (last_slash > last_backslash) ? last_slash + 1 : last_backslash + 1;
@@ -19,11 +19,41 @@ const char* get_short_filename(const char *filepath) {
     } else if (last_backslash) {
         return last_backslash + 1;
     }
-    
+
     return filepath;
 }
 
 // Funkcja obliczająca indeks piksela w obrazie jednowymiarowym
 size_t pixel_index(int x, int y, int width) {
     return (size_t)(y * width + x);
+}
+
+const char* detect_band_from_filename(const char* filename) {
+    if (filename == NULL) return "UNKNOWN";
+
+    if (strstr(filename, "B04") || strstr(filename, "_B04_")) return "B04";
+    if (strstr(filename, "B08") || strstr(filename, "_B08_")) return "B08";
+    if (strstr(filename, "B11") || strstr(filename, "_B11_")) return "B11";
+    if (strstr(filename, "SCL") || strstr(filename, "_SCL_")) return "SCL";
+
+    return "UNKNOWN";
+}
+
+char* get_timestamp() {
+    static char timestamp[64];
+    struct timeval tv;
+    struct tm* tm_info;
+
+    gettimeofday(&tv, NULL);
+    tm_info = localtime(&tv.tv_sec);
+
+    snprintf(timestamp, sizeof(timestamp), "%02d:%02d:%02d.%03ld",
+             tm_info->tm_hour, tm_info->tm_min, tm_info->tm_sec,
+             tv.tv_usec / 1000);
+
+    return timestamp;
+}
+
+double get_time_diff(struct timeval start, struct timeval end) {
+    return (end.tv_sec - start.tv_sec) + (end.tv_usec - start.tv_usec) / 1000000.0;
 }

--- a/utils.c
+++ b/utils.c
@@ -57,3 +57,11 @@ char* get_timestamp() {
 double get_time_diff(struct timeval start, struct timeval end) {
     return (end.tv_sec - start.tv_sec) + (end.tv_usec - start.tv_usec) / 1000000.0;
 }
+
+// Funkcja do zaciskania wartości do zakresu
+int clamp(int value, int min, int max)
+{
+    if (value < min) return min;
+    if (value > max) return max;
+    return value;
+}

--- a/utils.h
+++ b/utils.h
@@ -2,9 +2,12 @@
 #define UTILS_H
 
 #include <string.h>
+#include <sys/time.h>
 
 const char* get_short_filename(const char *filepath);
-
 size_t pixel_index(int x, int y, int width);
+const char* detect_band_from_filename(const char* filename);
+char* get_timestamp();
+double get_time_diff(struct timeval start, struct timeval end);
 
 #endif

--- a/utils.h
+++ b/utils.h
@@ -9,5 +9,6 @@ size_t pixel_index(int x, int y, int width);
 const char* detect_band_from_filename(const char* filename);
 char* get_timestamp();
 double get_time_diff(struct timeval start, struct timeval end);
+int clamp(int value, int min, int max);
 
 #endif


### PR DESCRIPTION
Kompletny refactor data_loader oraz gui. Wprowadzone ulepszenia tu i tam.

Nowe moduły:
- `gui_utils` - funkcje typu "utwórz przycisk", "wyświetl okienko modalne" itd.
- `processing_pipeline` - wyeksportowałem tam całą funkcję `process_bands_and_calculate_indices` żeby nie siedziało w module GUI
- `data_types.h` - definicja podstawowych struktur (~~cholerne~~ kochane C nie ma klas)

`resample` nie eksportuje już 3 różnych funkcji, tylko jedną która konwertuje wszystkie pasma do danej rozdzielczości.
`index_calculator` ma liczenie czasu (spójne z pozostałymi modułami).

Nie zmieniłem nazw ani parametrów funkcji, które były deklarowane jako API w plikach `.h` (np. `LoadBandData` w `data_loader`, które jest używane w innych modułach). Tam gdzie się da dałem wypisywanie do konsoli, później można to dodać do wyświetlania w GUI. 

Duże funkcje oraz funkcje API mają dokumentację Doxygen.